### PR TITLE
Add missing boost dependencies. Fixes #39

### DIFF
--- a/hub/iota/BUILD
+++ b/hub/iota/BUILD
@@ -22,6 +22,11 @@ cc_library(
         "@org_iota_entangled//common/helpers:digest",
         "@org_iota_entangled//common/model:transaction",
         "@com_github_google_glog//:glog",
+        "@boost//:config",
+        "@boost//:core",
+        "@boost//:fusion",
+        "@boost//:move",
+        "@boost//:range"
     ], )
 
 cc_library(

--- a/hub/service/BUILD
+++ b/hub/service/BUILD
@@ -26,6 +26,7 @@ cc_library(
         "@boost//:multi_index",
         "@boost//:range",
         "@boost//:move",
+        "@boost//:uuid"
     ],
     visibility=["//visibility:public"])
 

--- a/hub/stats/BUILD
+++ b/hub/stats/BUILD
@@ -4,5 +4,6 @@ cc_library(
     srcs=glob(["**/*.cc"]),
     deps=[
         "@com_github_google_glog//:glog",
+        "@boost//:uuid"
     ],
     visibility=["//visibility:public"])


### PR DESCRIPTION
Add `boost` bazel deps where missing.

# Test Plan:
Use a docker container without boost and see if rpchub builds correctly.
