### PR TITLE
hub/commands: UserWithdraw - Prevent crash if payoutAddress is invalid

### DIFF
--- a/hub/commands/tests/test_user_withdraw.cc
+++ b/hub/commands/tests/test_user_withdraw.cc
@@ -16,6 +16,25 @@ using namespace sqlpp;
 namespace {
 class UserWithdrawTest : public CommandTest {};
 
+TEST_F(UserWithdrawTest, ErrorOnInvalidPayoutAddress) {
+  rpc::UserWithdrawRequest req;
+  rpc::UserWithdrawReply res;
+  cmd::UserWithdraw command(session());
+
+  createUser(session(), "a");
+
+  req.set_userid("a");
+  req.set_amount(0);
+
+  req.set_payoutaddress("999999999");
+  ASSERT_FALSE(command.doProcess(&req, &res).ok());
+
+  req.set_payoutaddress(
+      "999999999999999999999999999999999999999999999999999999999999999999999999"
+      "99999|999");
+  ASSERT_FALSE(command.doProcess(&req, &res).ok());
+}
+
 TEST_F(UserWithdrawTest, ErrorOnZeroAmount) {
   rpc::UserWithdrawRequest req;
   rpc::UserWithdrawReply res;

--- a/hub/commands/user_withdraw.cc
+++ b/hub/commands/user_withdraw.cc
@@ -32,7 +32,6 @@ grpc::Status UserWithdraw::doProcess(
   uint64_t withdrawalId;
 
   auto withdrawalUUID = boost::uuids::random_generator()();
-  auto payoutAddress = hub::crypto::Address(request->payoutaddress());
 
   if (request->amount() <= 0) {
     return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "",
@@ -40,6 +39,8 @@ grpc::Status UserWithdraw::doProcess(
   }
 
   try {
+    auto payoutAddress = hub::crypto::Address(request->payoutaddress());
+
     // Get userId for identifier
     {
       auto maybeUserId = connection.userIdFromIdentifier(request->userid());


### PR DESCRIPTION
Current hub crashes if payout address is invalid because `hub::crypto::Address` constructor can throw
Fixes #117 

# Test Plan:
Tests added.
