### PR TITLE
schema: change trytes column type to LONGTEXT

### DIFF
--- a/schema/ddl2cpp
+++ b/schema/ddl2cpp
@@ -261,6 +261,7 @@ types = {
     'char': 'char_',
     'varchar': 'varchar',
     'text': 'text',
+    'longtext': 'text',
     'clob': 'text',
     'tinyblob': 'blob',
     'blob': 'blob',

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -38,7 +38,7 @@ CREATE INDEX idx_hub_address_balance ON hub_address(balance);
 CREATE TABLE IF NOT EXISTS sweep (
   id INTEGER PRIMARY KEY /*!40101 AUTO_INCREMENT */,
   bundle_hash CHAR(81) NOT NULL UNIQUE,
-  trytes TEXT NOT NULL,
+  trytes LONGTEXT NOT NULL,
   into_hub_address INTEGER NOT NULL,
   confirmed INTEGER DEFAULT 0 NOT NULL,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,


### PR DESCRIPTION
# Description

A sweep bundle can end up being larger 24 transactions.
MariaDB, being awesome as always, is very happy large strings in the TEXT field /s. (not!)

Fixes # (issue)

## Type of change

_Please delete options that are not relevant._

- Bug fix (a non-breaking change which fixes an issue)


# How Has This Been Tested?

Tests run, operationally tested to work as well.
