### PR TITLE
hub/auth: hmac path - truncate key if need be

### DIFF
--- a/hub/auth/hmac_provider.cc
+++ b/hub/auth/hmac_provider.cc
@@ -17,8 +17,7 @@ namespace auth {
 HMACProvider::HMACProvider(const std::string& key) : _key(key) {
   if (_key.size() > KEY_SIZE) {
     _key.resize(KEY_SIZE);
-  }
-  if (_key.size() < KEY_SIZE) {
+  } else if (_key.size() < KEY_SIZE) {
     throw std::runtime_error(
         __FUNCTION__ +
         std::string("Provided HMAC key has wrong size (expected size: ") +

--- a/hub/auth/hmac_provider.cc
+++ b/hub/auth/hmac_provider.cc
@@ -15,7 +15,10 @@ namespace hub {
 namespace auth {
 
 HMACProvider::HMACProvider(const std::string& key) : _key(key) {
-  if (_key.size() != KEY_SIZE) {
+  if (_key.size() > KEY_SIZE) {
+    _key.resize(KEY_SIZE);
+  }
+  if (_key.size() < KEY_SIZE) {
     throw std::runtime_error(
         __FUNCTION__ +
         std::string("Provided HMAC key has wrong size (expected size: ") +


### PR DESCRIPTION

# Description

Minor fix to allow longer key sizes for hmac (or terminating characters) 
Longer inputs will be truncated to KEY_SIZE

_Please delete items that are not relevant._

- [ ] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
