### PR TITLE
Changed url to 001-sign_bundle.md

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -3,7 +3,7 @@
 ## Before we start:
 - Hub is not an IOTA node, it is a tool for managing transfers from/to addresses in a simple and secure manner
 - User should send tokens to a deposit address only once, since deposit addresses are swept and aren't reusable
-- In case user sent tokens to a deposit address that has been swept, we offer a mechanism to recover the funds (see docs/hip/001-get_address_secret.md)
+- In case user sent tokens to a deposit address that has been swept, we offer a mechanism to recover the funds (see docs/hip/001-sign_bundle.md)
 - To facilitate toolchain / build environment setup we have provided toolchain configurations to build the Hub against. 
   To use these, see the [toolchains repository](https://github.com/iotaledger/toolchains) for more details. 
   As an example, to use the provided `x86-64-core-i7` toolchain, you'd build the signing server like this: 


### PR DESCRIPTION
The page was referencing the wrong document.

<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description

There was a reference to the wrong document. It confused me upon first read. This corrects it. 

used to say `see docs/hip/001-get_address_secret.md` now it says `see docs/hip/001-sign_bundle.md`

## Type of change
- Documentation Fix