### PR TITLE
Fix crash in pow

### DIFF
--- a/hub/auth/hmac_provider.cc
+++ b/hub/auth/hmac_provider.cc
@@ -15,7 +15,10 @@ namespace hub {
 namespace auth {
 
 HMACProvider::HMACProvider(const std::string& key) : _key(key) {
-  if (_key.size() != KEY_SIZE) {
+  if (_key.size() > KEY_SIZE) {
+    _key.resize(KEY_SIZE);
+  }
+  if (_key.size() < KEY_SIZE) {
     throw std::runtime_error(
         __FUNCTION__ +
         std::string("Provided HMAC key has wrong size (expected size: ") +


### PR DESCRIPTION
# Description

Fix crash on attachment_service, when `attachToTangle` fails, returned vector is empty,
should not access it!
also, log for other possible failures in `reattachSweep` which does `attachToTangle` for the sweep


## Type of change

_Please delete options that are not relevant._

- Bug fix (a non-breaking change which fixes an issue)


# Checklist:

_Please delete items that are not relevant._

- [ ] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
