### PR TITLE
hub/helper - align all timestamps to be set via code rather than sql

### DIFF
--- a/hub/db/helper.cc
+++ b/hub/db/helper.cc
@@ -104,10 +104,13 @@ uint64_t helper<C>::createUserAddress(C& connection,
                                       const common::crypto::UUID& uuid) {
   db::sql::UserAddress userAddress;
 
-  return connection(insert_into(userAddress)
-                        .set(userAddress.address = address.str(),
-                             userAddress.userId = userId,
-                             userAddress.seedUuid = uuid.str()));
+  auto now = ::sqlpp::chrono::floor<::std::chrono::milliseconds>(
+      std::chrono::system_clock::now());
+
+  return connection(
+      insert_into(userAddress)
+          .set(userAddress.address = address.str(), userAddress.userId = userId,
+               userAddress.seedUuid = uuid.str(), userAddress.createdAt = now));
 }
 
 template <typename C>
@@ -118,15 +121,19 @@ void helper<C>::createUserAddressBalanceEntry(
     nonstd::optional<uint64_t> sweepId) {
   db::sql::UserAddressBalance bal;
 
+  auto now = ::sqlpp::chrono::floor<::std::chrono::milliseconds>(
+      std::chrono::system_clock::now());
+
   if (reason == UserAddressBalanceReason::DEPOSIT) {
+    connection(insert_into(bal).set(
+        bal.userAddress = addressId, bal.amount = amount,
+        bal.reason = static_cast<int>(reason),
+        bal.tailHash = std::move(tailHash.value()), bal.occuredAt = now));
+  } else {
     connection(
         insert_into(bal).set(bal.userAddress = addressId, bal.amount = amount,
                              bal.reason = static_cast<int>(reason),
-                             bal.tailHash = std::move(tailHash.value())));
-  } else {
-    connection(insert_into(bal).set(
-        bal.userAddress = addressId, bal.amount = amount,
-        bal.reason = static_cast<int>(reason), bal.sweep = sweepId.value()));
+                             bal.sweep = sweepId.value(), bal.occuredAt = now));
   }
 }
 
@@ -137,18 +144,24 @@ void helper<C>::createUserAccountBalanceEntry(
     const nonstd::optional<uint64_t> fkey) {
   db::sql::UserAccountBalance bal;
 
+  auto now = ::sqlpp::chrono::floor<::std::chrono::milliseconds>(
+      std::chrono::system_clock::now());
+
   if (reason == UserAccountBalanceReason::SWEEP) {
     connection(insert_into(bal).set(bal.userId = userId, bal.amount = amount,
                                     bal.reason = static_cast<int>(reason),
-                                    bal.sweep = fkey.value()));
+                                    bal.sweep = fkey.value(),
+                                    bal.occuredAt = now));
   } else if (reason == UserAccountBalanceReason::WITHDRAWAL ||
              reason == UserAccountBalanceReason::WITHDRAWAL_CANCEL) {
     connection(insert_into(bal).set(bal.userId = userId, bal.amount = amount,
                                     bal.reason = static_cast<int>(reason),
-                                    bal.withdrawal = fkey.value()));
+                                    bal.withdrawal = fkey.value(),
+                                    bal.occuredAt = now));
   } else {
     connection(insert_into(bal).set(bal.userId = userId, bal.amount = amount,
-                                    bal.reason = static_cast<int>(reason)));
+                                    bal.reason = static_cast<int>(reason),
+                                    bal.occuredAt = now));
   }
 }
 
@@ -245,7 +258,11 @@ void helper<C>::createTail(C& connection, uint64_t sweepId,
                            const std::string& hash) {
   db::sql::SweepTails tls;
 
-  connection(insert_into(tls).set(tls.sweep = sweepId, tls.hash = hash));
+  auto now = ::sqlpp::chrono::floor<::std::chrono::milliseconds>(
+      std::chrono::system_clock::now());
+
+  connection(insert_into(tls).set(tls.sweep = sweepId, tls.hash = hash,
+                                  tls.createdAt = now));
 }
 
 template <typename C>
@@ -468,6 +485,9 @@ void helper<C>::insertUserTransfers(
   if (transfers.empty()) {
     return;
   }
+  auto now = ::sqlpp::chrono::floor<::std::chrono::milliseconds>(
+      std::chrono::system_clock::now());
+
   auto multi_insert =
       insert_into(bal).columns(bal.userId, bal.amount, bal.reason);
 
@@ -547,8 +567,12 @@ int64_t helper<C>::createHubAddress(C& connection,
                                     const common::crypto::Address& address) {
   db::sql::HubAddress tbl;
 
+  auto now = ::sqlpp::chrono::floor<::std::chrono::milliseconds>(
+      std::chrono::system_clock::now());
+
   return connection(insert_into(tbl).set(tbl.seedUuid = uuid.str(),
-                                         tbl.address = address.str()));
+                                         tbl.address = address.str(),
+                                         tbl.createdAt = now));
 }
 
 template <typename C>
@@ -557,9 +581,13 @@ void helper<C>::createHubAddressBalanceEntry(
     const HubAddressBalanceReason reason, uint64_t sweepId) {
   db::sql::HubAddressBalance bal;
 
-  connection(insert_into(bal).set(
-      bal.hubAddress = hubAddress, bal.amount = amount,
-      bal.reason = static_cast<int>(reason), bal.sweep = sweepId));
+  auto now = ::sqlpp::chrono::floor<::std::chrono::milliseconds>(
+      std::chrono::system_clock::now());
+
+  connection(insert_into(bal).set(bal.hubAddress = hubAddress,
+                                  bal.amount = amount,
+                                  bal.reason = static_cast<int>(reason),
+                                  bal.sweep = sweepId, bal.occuredAt = now));
 }
 
 template <typename C>
@@ -586,9 +614,12 @@ int64_t helper<C>::createSweep(C& connection,
                                uint64_t intoHubAddress) {
   db::sql::Sweep tbl;
 
-  return connection(insert_into(tbl).set(tbl.bundleHash = bundleHash.str(),
-                                         tbl.trytes = bundleTrytes,
-                                         tbl.intoHubAddress = intoHubAddress));
+  auto now = ::sqlpp::chrono::floor<::std::chrono::milliseconds>(
+      std::chrono::system_clock::now());
+
+  return connection(insert_into(tbl).set(
+      tbl.bundleHash = bundleHash.str(), tbl.trytes = bundleTrytes,
+      tbl.intoHubAddress = intoHubAddress, tbl.createdAt = now));
 }
 
 template <typename C>


### PR DESCRIPTION
# Description
Align all timestamps in db records created via helper, meaning that helper will assign the value rather than let sql to insert the default value

_Please delete options that are not relevant._

- Bug fix (a non-breaking change which fixes an issue)

# Checklist:

_Please delete items that are not relevant._

- [ ] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
