### PR TITLE
Hub: attachment_service - pick first tail and log error

### DIFF
--- a/hub/service/attachment_service.cc
+++ b/hub/service/attachment_service.cc
@@ -43,16 +43,19 @@ bool AttachmentService::checkSweepTailsForConfirmation(
   LOG(INFO) << "Sweep: " << sweep.id << " (" << sweep.bundleHash
             << ") has: " << confirmedTails.size() << " confirmed tails.";
 
-  if (confirmedTails.size() == 1) {
-    const auto& tail = *confirmedTails.cbegin();
-    LOG(INFO) << "Marking tail as confirmed: " << tail;
-    connection.markTailAsConfirmed(tail);
-    return true;
-  } else if (confirmedTails.size() > 1) {
-    LOG(FATAL) << "More than one confirmed tail!!!";
+  if (confirmedTails.empty()) {
+    return false;
   }
 
-  return false;
+  const auto& tail = *confirmedTails.cbegin();
+  LOG(INFO) << "Marking tail as confirmed: " << tail;
+  connection.markTailAsConfirmed(tail);
+  if (confirmedTails.size() > 1) {
+    LOG(ERROR) << "More than one confirmed tail for sweep: " << sweep.id
+               << " bundle hash: " << sweep.bundleHash;
+  }
+
+  return true;
 }
 
 bool AttachmentService::checkForUserReattachment(

--- a/hub/service/attachment_service.cc
+++ b/hub/service/attachment_service.cc
@@ -53,6 +53,11 @@ bool AttachmentService::checkSweepTailsForConfirmation(
   if (confirmedTails.size() > 1) {
     LOG(ERROR) << "More than one confirmed tail for sweep: " << sweep.id
                << " bundle hash: " << sweep.bundleHash;
+    auto ignoredTailIt = (++confirmedTails.begin());
+    LOG(INFO) << "Ignored tails:";
+    while (ignoredTailIt != confirmedTails.end()) {
+      LOG(INFO) << *ignoredTailIt++;
+    }
   }
 
   return true;

--- a/hub/service/attachment_service.cc
+++ b/hub/service/attachment_service.cc
@@ -47,16 +47,15 @@ bool AttachmentService::checkSweepTailsForConfirmation(
     return false;
   }
 
-  const auto& tail = *confirmedTails.cbegin();
-  LOG(INFO) << "Marking tail as confirmed: " << tail;
-  connection.markTailAsConfirmed(tail);
+  auto tailIt = confirmedTails.cbegin();
+  LOG(INFO) << "Marking tail as confirmed: " << *tailIt;
+  connection.markTailAsConfirmed(*tailIt);
   if (confirmedTails.size() > 1) {
     LOG(ERROR) << "More than one confirmed tail for sweep: " << sweep.id
                << " bundle hash: " << sweep.bundleHash;
-    auto ignoredTailIt = (++confirmedTails.begin());
     LOG(INFO) << "Ignored tails:";
-    while (ignoredTailIt != confirmedTails.end()) {
-      LOG(INFO) << *ignoredTailIt++;
+    while (++tailIt != confirmedTails.cend()) {
+      LOG(INFO) << *tailIt;
     }
   }
 


### PR DESCRIPTION
# Description

In the scenario where a deposit address has been funded multiple times, one or more times after the `user_address_monitor` service marks/detects the deposit address with the initial fund,
and when `attachment_service` was able to attach a bundle and get it confirmed only after few reattachments have been processed, since the bundle spends the deposit address for the initial funding that means that the deposit address is not being spent in its entirety,so following reattachments can succeed, causing a FATAL error on hub

As a solution, we don't log FATAL (which stops the hub process) but we log ERROR, and we pick the first tail as the one confirmed for the sweep,

Fixes # (issue)

## Type of change

- Bug fix (a non-breaking change which fixes an issue)


# Checklist:

_Please delete items that are not relevant._

- [ ] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
