### PR TITLE
Additional validation for withdrawal address

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,7 +17,7 @@ AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: true
+AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:   
@@ -39,6 +39,7 @@ BraceWrapping:
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Attach
 BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
@@ -81,28 +82,58 @@ MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
 ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: false
+ObjCSpaceBeforeProtocolList: true
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
 RawStringFormats: 
-  - Delimiter:       pb
-    Language:        TextProto
+  - Language:        Cpp
+    Delimiters:      
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:      
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions: 
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
     BasedOnStyle:    google
 ReflowComments:  true
-SortIncludes:    true
+SortIncludes:    false
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
 SpacesInAngles:  false

--- a/hub/commands/tests/helper.cc
+++ b/hub/commands/tests/helper.cc
@@ -34,5 +34,11 @@ std::map<uint64_t, int64_t> createBalanceForUsers(std::vector<uint64_t> ids,
   return idsToBalances;
 }
 
+hub::rpc::ErrorCode errorCodeFromDetails(const std::string& errorStr) {
+  hub::rpc::Error error;
+  error.ParseFromString(errorStr);
+  return error.code();
+}
+
 }  // namespace tests
 }  // namespace hub

--- a/hub/commands/tests/helper.h
+++ b/hub/commands/tests/helper.h
@@ -21,6 +21,8 @@ std::map<uint64_t, int64_t> createZigZagTransfer(
     std::vector<std::string>& users, rpc::ProcessTransferBatchRequest& req,
     int64_t absAmount);
 
+hub::rpc::ErrorCode errorCodeFromDetails(const std::string& errorStr);
+
 }  // namespace tests
 
 }  // namespace hub

--- a/hub/commands/tests/test_user_withdraw.cc
+++ b/hub/commands/tests/test_user_withdraw.cc
@@ -84,6 +84,30 @@ TEST_F(UserWithdrawTest, WithdrawalUpdatesUserBalance) {
   ASSERT_EQ(50, balRes.available());
 }
 
+TEST_F(UserWithdrawTest, ErrorOnInvalidAddress) {
+  rpc::UserWithdrawRequest req;
+  rpc::UserWithdrawReply res;
+  cmd::UserWithdraw command(session());
+
+  constexpr auto username = "User1";
+
+  createUser(session(), username);
+
+  req.set_userid(username);
+  createBalanceForUsers({1}, 100);
+  req.set_amount(50);
+  req.set_validatechecksum(false);
+
+  // Last letter is F => [0,-1, *1*]
+  req.set_payoutaddress(
+      "WLVZXWARPSYCWJMBZJGXHUOVYBVCEKMNQDMXHCAEJZFLFLMHFYYQQSSLVYWAZWESKXZOROLU"
+      "9OQFRVDEF");
+
+  auto status = command.doProcess(&req, &res);
+
+  ASSERT_FALSE(status.ok());
+}
+
 TEST_F(UserWithdrawTest, ErrorOnInvalidChecksumForPayoutAddress) {
   rpc::UserWithdrawRequest req;
   rpc::UserWithdrawReply res;
@@ -96,6 +120,7 @@ TEST_F(UserWithdrawTest, ErrorOnInvalidChecksumForPayoutAddress) {
   req.set_userid(username);
   createBalanceForUsers({1}, 100);
   req.set_amount(50);
+  req.set_validatechecksum(true);
 
   // checksum last letter: Y -> Z
   req.set_payoutaddress(

--- a/hub/commands/tests/test_user_withdraw.cc
+++ b/hub/commands/tests/test_user_withdraw.cc
@@ -104,8 +104,10 @@ TEST_F(UserWithdrawTest, ErrorOnInvalidAddress) {
       "9OQFRVDEF");
 
   auto status = command.doProcess(&req, &res);
-
   ASSERT_FALSE(status.ok());
+
+  ASSERT_EQ(hub::rpc::ErrorCode::INELIGIBLE_ADDRESS,
+            errorCodeFromDetails(status.error_details()));
 }
 
 TEST_F(UserWithdrawTest, ErrorOnInvalidChecksumForPayoutAddress) {

--- a/hub/commands/user_withdraw.cc
+++ b/hub/commands/user_withdraw.cc
@@ -32,7 +32,6 @@ grpc::Status UserWithdraw::doProcess(
     const hub::rpc::UserWithdrawRequest* request,
     hub::rpc::UserWithdrawReply* response) noexcept {
   auto& connection = db::DBManager::get().connection();
-  auto transaction = connection.transaction();
 
   nonstd::optional<hub::rpc::ErrorCode> errorCode;
   uint64_t userId;
@@ -51,23 +50,44 @@ grpc::Status UserWithdraw::doProcess(
                         errorToString(hub::rpc::ErrorCode::EC_UNKNOWN));
   }
 
-  try {
-    nonstd::optional<common::crypto::Address> address;
-    if (request->validatechecksum()) {
-      address =
-          std::move(common::crypto::CryptoManager::get()
-                        .provider()
-                        .verifyAndStripChecksum(request->payoutaddress()));
+  nonstd::optional<common::crypto::Address> address;
+  if (request->validatechecksum()) {
+    address = std::move(
+        common::crypto::CryptoManager::get().provider().verifyAndStripChecksum(
+            request->payoutaddress()));
 
-      if (!address.has_value()) {
-        return grpc::Status(
-            grpc::StatusCode::FAILED_PRECONDITION, "",
-            errorToString(hub::rpc::ErrorCode::CHECKSUM_INVALID));
-      }
-    } else {
-      address = {common::crypto::Address(request->payoutaddress())};
+    if (!address.has_value()) {
+      return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "",
+                          errorToString(hub::rpc::ErrorCode::CHECKSUM_INVALID));
     }
+  } else {
+    address = {common::crypto::Address(request->payoutaddress())};
+  }
 
+  if (address.has_value()) {
+    // Currently, all IOTA addresses' last trit must be 0.
+    // This means 9ABCDWXYZ'
+
+    switch (address->str_view()[80]) {
+      case '9':
+      case 'A':
+      case 'B':
+      case 'C':
+      case 'D':
+      case 'W':
+      case 'X':
+      case 'Y':
+      case 'Z':
+        break;
+      default:
+        return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "",
+                            errorToString(hub::rpc::ErrorCode::EC_UNKNOWN));
+    }
+  }
+
+  auto transaction = connection.transaction();
+
+  try {
     common::crypto::Tag withdrawalTag(
         request->tag() +
         std::string(common::crypto::Tag::length() - request->tag().size(),
@@ -124,6 +144,7 @@ grpc::Status UserWithdraw::doProcess(
     errorCode = hub::rpc::ErrorCode::EC_UNKNOWN;
   }
 
+done:
   if (errorCode) {
     return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "",
                         errorToString(errorCode.value()));

--- a/hub/commands/user_withdraw.cc
+++ b/hub/commands/user_withdraw.cc
@@ -86,8 +86,9 @@ grpc::Status UserWithdraw::doProcess(
     case 'Z':
       break;
     default:
-      return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "",
-                          errorToString(hub::rpc::ErrorCode::EC_UNKNOWN));
+      return grpc::Status(
+          grpc::StatusCode::FAILED_PRECONDITION, "",
+          errorToString(hub::rpc::ErrorCode::INELIGIBLE_ADDRESS));
   }
 
   auto transaction = connection.transaction();

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -12,7 +12,7 @@ package hub.rpc;
   Error codes that can be returned by the hub.
  */
 enum ErrorCode {
-  // Unused.
+  // Generic error drop-in.
   EC_UNKNOWN = 0;
   // UserId already exists.
   USER_EXISTS = 1;


### PR DESCRIPTION
We weren't validating the withdrawal address and thus allowing withdrawals to addresses such as `FIQUWUJQD9FCIROQM9DZMZKVOJOBEAUNEOTPQSLWHZPWJLGRYHFQ9XZGVM9RKGCJHG9AUDDLLKFJJCJTM`.

IRI currently rejects these addresses due to constraints via Kerl. This PR makes sure that users can be a bit less knowledgeable about such details ;) 