### PR TITLE
WORKSPACE: move from pubref grpc to upstream grpc bazel support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,10 +4,12 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_r
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # EXTERNAL RULES
-git_repository(
-    name = "org_pubref_rules_protobuf",
-    commit = "0c59d9145c0d3bfba2a61a04392a950b088a9b83",
-    remote = "https://github.com/pubref/rules_protobuf",
+http_archive(
+    name = "com_github_grpc_grpc",
+    urls = [
+        "https://github.com/grpc/grpc/archive/d2c7d4dea492b9a86a53555aabdbfa90c2b01730.tar.gz",
+    ],
+    strip_prefix = "grpc-d2c7d4dea492b9a86a53555aabdbfa90c2b01730",
 )
 
 git_repository(
@@ -102,32 +104,15 @@ load(
     "@io_bazel_rules_docker//cc:image.bzl",
     _cc_image_repos = "repositories",
 )
-load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cpp_proto_repositories")
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_prefix",
-    "go_register_toolchains",
-    "go_rules_dependencies",
-)
-load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_repositories")
-load(
-    "@org_pubref_rules_protobuf//grpc_gateway:rules.bzl",
-    "grpc_gateway_proto_repositories",
-)
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
 load("@iota_toolchains//:toolchains.bzl", "setup_toolchains")
+
+grpc_deps()
 
 setup_toolchains()
 
 iota_deps()
 
 _cc_image_repos()
-
-cpp_proto_repositories()
-
-go_rules_dependencies()
-
-go_register_toolchains()
-
-go_proto_repositories()
-
-grpc_gateway_proto_repositories()

--- a/common/BUILD
+++ b/common/BUILD
@@ -8,7 +8,8 @@ cc_library(
     deps = [
         "//common/crypto:types",
         "//common/stats",
-        "//proto:hub_cpp",
+        "//proto:hub_grpc_cc",
+        "@com_github_grpc_grpc//:grpc++",
         "@com_github_gflags_gflags//:gflags",
         "@com_github_google_glog//:glog",
     ],

--- a/common/common.h
+++ b/common/common.h
@@ -11,7 +11,7 @@
 #include <memory>
 #include <string>
 
-#include <grpc++/grpc++.h>
+#include "grpc++/grpc++.h"
 
 namespace common {
 

--- a/common/crypto/BUILD
+++ b/common/crypto/BUILD
@@ -11,7 +11,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":types",
-        "//proto:signing_server_cpp",
+        "//proto:signing_server_grpc_cc",
         "@optional_lite",
         "@org_iota_entangled//common/helpers:checksum",
     ],

--- a/common/server_base.h
+++ b/common/server_base.h
@@ -11,7 +11,7 @@
 #include <memory>
 #include <string>
 
-#include <grpc++/grpc++.h>
+#include "grpc++/grpc++.h"
 
 namespace common {
 

--- a/hub/commands/BUILD
+++ b/hub/commands/BUILD
@@ -11,7 +11,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//common/stats",
-        "//proto:hub_cpp",
+        "//proto:hub_grpc_cc",
     ],
 )
 
@@ -31,7 +31,7 @@ cc_library(
         "//common/stats",
         "//hub/auth:hmac_provider",
         "//hub/db",
-        "//proto:hub_cpp",
+        "//proto:hub_grpc_cc",
         "@boost//:range",
         "@com_github_google_glog//:glog",
     ],

--- a/hub/crypto/BUILD
+++ b/hub/crypto/BUILD
@@ -23,7 +23,7 @@ cc_library(
         "//common",
         "//common/crypto",
         "//hub/db",
-        "//proto:signing_server_cpp",
+        "//proto:signing_server_grpc_cc",
         "@optional_lite",
     ],
 )

--- a/hub/server/BUILD
+++ b/hub/server/BUILD
@@ -19,7 +19,7 @@ cc_library(
         "//hub/service:attachment_service",
         "//hub/service:sweep_service",
         "//hub/service:user_address_monitor",
-        "//proto:hub_cpp",
+        "//proto:hub_grpc_cc",
         "@com_github_gflags_gflags//:gflags",
         "@com_github_google_glog//:glog",
         "@org_iota_entangled//cppclient:beast",

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -1,47 +1,44 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_pubref_rules_protobuf//protobuf:rules.bzl", "proto_language")
-load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cc_proto_library")
-load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
-load(
-    "@org_pubref_rules_protobuf//grpc_gateway:rules.bzl",
-    "GRPC_GATEWAY_DEPS",
-    "grpc_gateway_proto_library",
-)
+load("@com_github_grpc_grpc//:bazel/cc_grpc_library.bzl", "cc_grpc_library")
 
-filegroup(
-    name = "protos",
+proto_library(
+    name = "messages_proto",
     srcs = ["messages.proto"],
 )
 
-filegroup(
-    name = "signing_server_protos",
+cc_grpc_library(
+    name = "messages_proto_cc",
+    srcs= ["messages.proto"],
+    deps=[], well_known_protos=False,
+    proto_only =  True,
+)
+
+cc_grpc_library(
+    name = "hub_grpc_cc",
+    srcs = ["hub.proto"],
+    proto_only=False,
+    well_known_protos=False,
+    generate_mocks = True,
+    deps = [":messages_proto_cc"],
+)
+
+proto_library(
+    name = "signing_server_messages_proto",
     srcs = ["signing_server_messages.proto"],
 )
 
-cc_proto_library(
-    name = "hub_cpp",
-    protos = [
-        "hub.proto",
-        ":protos",
-    ],
-    verbose = 0,
-    with_grpc = True,
+cc_grpc_library(
+    name = "signing_server_messages_proto_cc",
+    srcs = ["signing_server_messages.proto"],
+    deps=[], well_known_protos=False,
+    proto_only =  True,
 )
 
-cc_proto_library(
-    name = "signing_server_cpp",
-    protos = [
-        "signing_server.proto",
-        ":signing_server_protos",
-    ],
-    verbose = 0,
-    with_grpc = True,
+cc_grpc_library(
+    name = "signing_server_grpc_cc",
+    proto_only=False,
+    well_known_protos=False,
+    srcs = ["signing_server.proto"],
+    deps = [":signing_server_messages_proto_cc"],
 )
-
-# Currently broken in rules_protobuf.
-#grpc_gateway_proto_library(
-#    name="gateway",
-#    verbose=1,
-#    protos=["gateway.proto", ":protos"],
-#    visibility=["//visibility:public"], )

--- a/signing_server/commands/BUILD
+++ b/signing_server/commands/BUILD
@@ -15,6 +15,6 @@ cc_library(
     deps = [
         "//common",
         "//common/crypto:argon2_provider",
-        "//proto:signing_server_cpp",
+        "//proto:signing_server_grpc_cc",
     ],
 )

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,3 +1,6 @@
+# temporary until https://github.com/grpc/grpc/issues/17506 is resolved
+--incompatible_remove_native_http_archive=false 
+
 build --cxxopt='-std=c++17'
 test --copt='-ggdb3' 
 test --test_output=errors


### PR DESCRIPTION
PubRef gRPC is no longer compatible with latest bazel.
This adds usage of upstream grpc/grpc bazel support
Usage of gRPC >1.15 is pending https://github.com/grpc/grpc/issues/17506