### PR TITLE
hub/service: address_monitor should check for solidity

### DIFF
--- a/hub/service/address_monitor.cc
+++ b/hub/service/address_monitor.cc
@@ -16,6 +16,7 @@
 #include <utility>
 
 #include <gflags/gflags.h>
+#include <glog/logging.h>
 
 #include <boost/asio/io_service.hpp>
 #include <boost/bind.hpp>
@@ -96,6 +97,10 @@ void AddressMonitor::persistBalanceChanges(
 }
 
 bool AddressMonitor::doTick() {
+  if(!_api->isNodeSolid()) {
+    LOG(INFO) << "Node is not solid. Skipping address monitoring.";
+  }
+
   auto changes = calculateBalanceChanges();
 
   if (!changes.empty()) {

--- a/hub/service/address_monitor.cc
+++ b/hub/service/address_monitor.cc
@@ -99,6 +99,7 @@ void AddressMonitor::persistBalanceChanges(
 bool AddressMonitor::doTick() {
   if(!_api->isNodeSolid()) {
     LOG(INFO) << "Node is not solid. Skipping address monitoring.";
+    return true;
   }
 
   auto changes = calculateBalanceChanges();

--- a/hub/service/tests/address_monitor.cc
+++ b/hub/service/tests/address_monitor.cc
@@ -38,7 +38,8 @@ class MockAPI : public cppclient::IotaAPI {
  public:
   virtual ~MockAPI() {}
 
-  MOCK_METHOD0(isNodeSolid, bool());
+  virtual bool isNodeSolid() { return true; }
+  //MOCK_METHOD0(isNodeSolid, bool());
 
   MOCK_METHOD1(getBalances,
                nonstd::optional<std::unordered_map<std::string, uint64_t>>(


### PR DESCRIPTION
# Description

At the moment, if the IRI node is out of date, the address monitor will fail with a confusing error message (getBalances does not match expected). This should prevent that from happening.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

