### PR TITLE
hub: store deposit transaction's message if configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ See [Getting Started](docs/getting_started.md) for information on how to use the
     -sweepInterval (Sweep interval (0=disabled) [ms]) type: uint32
       default: 600000
     -powMode (Proof of work mode, local or remote)
+    -fetchTransactionMessages (Determines if Should store deposit transaction's message) 
+      type: bool (--fetchTransactionMessages or --nofetchTransactionMessages)
 
   Flags from hub/service/sweep_service.cc:
     -sweep_max_deposit (Maximum number of user deposits to process per sweep.)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -93,9 +93,9 @@ new_git_repository(
 
 http_archive(
     name = "org_iota_entangled",
-    sha256 = "5af2805d00dd9838ac5abe1759d376b37e354d3d50802534e79e74692d2f3011",
-    strip_prefix = "entangled-11a5156a35595a8f7172064b1ed8c63659ed50db",
-    url = "https://github.com/iotaledger/entangled/archive/11a5156a35595a8f7172064b1ed8c63659ed50db.zip",
+    sha256 = "140f10b8a8b9e6f2bb1864a177cd0f30244fd565ea905e4af90fef169e3b7a00",
+    strip_prefix = "entangled-1790f55de316772f55a27b8156904c1958bbe4e1",
+    url = "https://github.com/iotaledger/entangled/archive/1790f55de316772f55a27b8156904c1958bbe4e1.zip",
 )
 
 new_git_repository(

--- a/common/crypto/types.h
+++ b/common/crypto/types.h
@@ -123,6 +123,11 @@ class TryteArray {
 
   static constexpr std::size_t length() { return N; }
 
+  bool isNull() {
+    return std::all_of(_data.begin(), _data.end(),
+                       [](char c) { return (c == NULL_TRYTE); });
+  }
+
  private:
   /// Internal representation of the trytes
   std::array<uint8_t, N> _data;
@@ -143,11 +148,13 @@ struct HashTag {};
 struct AddressTag {};
 struct TagTag {};
 struct ChecksumTag {};
+struct MessageTag {};
 
 using Checksum = TryteArray<9, ChecksumTag>;
 using Hash = TryteArray<81, HashTag>;
 using Address = TryteArray<81, AddressTag>;
 using Tag = TryteArray<27, TagTag>;
+using Message = TryteArray<2187, MessageTag>;
 
 };  // namespace crypto
 }  // namespace common

--- a/hub/commands/balance_subscription.cc
+++ b/hub/commands/balance_subscription.cc
@@ -69,6 +69,7 @@ grpc::Status BalanceSubscription::doProcess(
     userAddressEvent->set_reason(userAddressBalanceEventTypeFromSql(b.reason));
     userAddressEvent->set_hash(std::move(b.hash));
     userAddressEvent->set_useraddress(std::move(b.userAddress));
+    userAddressEvent->set_message(std::move(b.message));
 
     event.set_allocated_useraddressevent(userAddressEvent);
     if (!writer->Write(event)) {

--- a/hub/db/connection.h
+++ b/hub/db/connection.h
@@ -80,7 +80,9 @@ class Connection {
   /// @param[in] tailHash - tailHash of the correpsonding transaction
   /// @param[in] sweepId - if the new balance is the result of a sweep
   virtual void createUserAddressBalanceEntry(
-      uint64_t addressId, int64_t amount, const UserAddressBalanceReason reason,
+      uint64_t addressId, int64_t amount,
+      nonstd::optional<common::crypto::Message> message,
+      const UserAddressBalanceReason reason,
       nonstd::optional<std::string> tailHash,
       nonstd::optional<uint64_t> sweepId) = 0;
 

--- a/hub/db/connection_impl.h
+++ b/hub/db/connection_impl.h
@@ -85,12 +85,14 @@ class ConnectionImpl : public Connection {
   }
 
   void createUserAddressBalanceEntry(
-      uint64_t addressId, int64_t amount, const UserAddressBalanceReason reason,
+      uint64_t addressId, int64_t amount,
+      nonstd::optional<common::crypto::Message> message,
+      const UserAddressBalanceReason reason,
       nonstd::optional<std::string> tailHash,
       nonstd::optional<uint64_t> sweepId) override {
-    db::helper<Conn>::createUserAddressBalanceEntry(*_conn, addressId, amount,
-                                                    reason, std::move(tailHash),
-                                                    std::move(sweepId));
+    db::helper<Conn>::createUserAddressBalanceEntry(
+        *_conn, addressId, amount, message, reason, std::move(tailHash),
+        std::move(sweepId));
   }
 
   void createUserAccountBalanceEntry(

--- a/hub/db/helper.h
+++ b/hub/db/helper.h
@@ -42,6 +42,7 @@ struct helper {
                                     const common::crypto::UUID& uuid);
   static void createUserAddressBalanceEntry(
       C& connection, uint64_t addressId, int64_t amount,
+      nonstd::optional<common::crypto::Message> message,
       const UserAddressBalanceReason reason,
       nonstd::optional<std::string> tailHash,
       nonstd::optional<uint64_t> sweepId);

--- a/hub/db/tests/trigger.cc
+++ b/hub/db/tests/trigger.cc
@@ -113,15 +113,18 @@ TEST_F(DBTest, UserAddressTriggerWorks) {
 
     for (auto i = 0; i < userBalances[userNum] / stepSize; ++i) {
       connection.createUserAddressBalanceEntry(
-          addId, stepSize, UserAddressBalanceReason::DEPOSIT, {""}, 1);
+          addId, stepSize, nonstd::nullopt, UserAddressBalanceReason::DEPOSIT,
+          {""}, 1);
     }
 
     // just so all types of REASONs will be tested
-    connection.createUserAddressBalanceEntry(
-        addId, -stepSize, UserAddressBalanceReason::SWEEP, {""}, sweepId);
+    connection.createUserAddressBalanceEntry(addId, -stepSize, nonstd::nullopt,
+                                             UserAddressBalanceReason::SWEEP,
+                                             {""}, sweepId);
 
-    connection.createUserAddressBalanceEntry(
-        addId, stepSize, UserAddressBalanceReason::DEPOSIT, {""}, 1);
+    connection.createUserAddressBalanceEntry(addId, stepSize, nonstd::nullopt,
+                                             UserAddressBalanceReason::DEPOSIT,
+                                             {""}, 1);
 
     ++userNum;
   }

--- a/hub/db/types.h
+++ b/hub/db/types.h
@@ -51,6 +51,7 @@ struct UserAddressBalanceEvent {
   // Bundle hash of sweep (if reason == SWEEP)
   std::string hash;
   std::chrono::system_clock::time_point timestamp;
+  std::string message;
 };
 
 struct HubAddressBalanceEvent {

--- a/hub/server/server.cc
+++ b/hub/server/server.cc
@@ -61,6 +61,11 @@ DEFINE_string(signingServerKeyCert, "/dev/null",
 // remote/local pow settings
 DEFINE_string(powMode, "remote", "PoW method to use {remote,local}");
 
+// Extended
+DEFINE_bool(fetchTransactionMessages, false,
+            "Whether or not should hub fetch messages from transactions that "
+            "are funding user addresses");
+
 using grpc::Server;
 using grpc::ServerBuilder;
 
@@ -126,7 +131,8 @@ void HubServer::initialise() {
   }
 
   _userAddressMonitor = std::make_unique<service::UserAddressMonitor>(
-      _api, std::chrono::milliseconds(FLAGS_monitorInterval));
+      _api, std::chrono::milliseconds(FLAGS_monitorInterval),
+      FLAGS_fetchTransactionMessages);
 
   _attachmentService = std::make_unique<service::AttachmentService>(
       _api, std::chrono::milliseconds(FLAGS_attachmentInterval));

--- a/hub/service/attachment_service.cc
+++ b/hub/service/attachment_service.cc
@@ -68,7 +68,8 @@ bool AttachmentService::checkForUserReattachment(
   VLOG(3) << __FUNCTION__;
   auto bundleTransactionHashes = _api->findTransactions(
       {}, std::vector<std::string>{sweep.bundleHash}, {});
-  auto bundleTransactions = _api->getTransactions(bundleTransactionHashes);
+  auto bundleTransactions =
+      _api->getTransactions(bundleTransactionHashes, false);
 
   // Remove non-tails or tails that we know of
   bundleTransactions.erase(

--- a/hub/service/sweep_service.cc
+++ b/hub/service/sweep_service.cc
@@ -208,8 +208,8 @@ void SweepService::persistToDatabase(
   // 6.4. Change User address balances
   for (const auto& input : deposits) {
     dbConnection.createUserAddressBalanceEntry(
-        input.addressId, -input.amount, db::UserAddressBalanceReason::SWEEP, {},
-        sweepId);
+        input.addressId, -input.amount, nonstd::nullopt,
+        db::UserAddressBalanceReason::SWEEP, {}, sweepId);
 
     dbConnection.createUserAccountBalanceEntry(
         input.userId, input.amount, db::UserAccountBalanceReason::SWEEP,

--- a/hub/service/tests/address_monitor.cc
+++ b/hub/service/tests/address_monitor.cc
@@ -45,9 +45,9 @@ class MockAPI : public cppclient::IotaAPI {
                nonstd::optional<std::unordered_map<std::string, uint64_t>>(
                    const std::vector<std::string>& addresses));
 
-  MOCK_METHOD1(getConfirmedBundlesForAddresses,
+  MOCK_METHOD2(getConfirmedBundlesForAddresses,
                std::unordered_multimap<std::string, Bundle>(
-                   const std::vector<std::string>& addresses));
+                   const std::vector<std::string>& addresses, bool));
 
   MOCK_METHOD2(filterConfirmedTails,
                std::unordered_set<std::string>(
@@ -62,8 +62,8 @@ class MockAPI : public cppclient::IotaAPI {
 
   MOCK_METHOD0(getNodeInfo, nonstd::optional<NodeInfo>());
 
-  MOCK_METHOD1(getTransactions,
-               std::vector<Transaction>(const std::vector<std::string>&));
+  MOCK_METHOD2(getTransactions,
+               std::vector<Transaction>(const std::vector<std::string>&, bool));
 
   MOCK_METHOD1(getTrytes,
                std::vector<std::string>(const std::vector<std::string>&));

--- a/hub/service/user_address_monitor.cc
+++ b/hub/service/user_address_monitor.cc
@@ -10,7 +10,6 @@
 #include <algorithm>
 #include <iterator>
 #include <set>
-#include <utility>
 #include <vector>
 
 #include <glog/logging.h>
@@ -67,7 +66,8 @@ bool UserAddressMonitor::onBalancesChanged(
                    std::back_inserter(ids),
                    [](const auto& change) { return change.addressId; });
 
-    auto confirmedBundlesMap = _api->getConfirmedBundlesForAddresses(addresses);
+    auto confirmedBundlesMap = _api->getConfirmedBundlesForAddresses(
+        addresses, _fetchTransactionMessage);
 
     auto tailsToAddresses = connection.tailsForUserAddresses(ids);
 
@@ -108,6 +108,10 @@ bool UserAddressMonitor::onBalancesChanged(
 
               connection.createUserAddressBalanceEntry(
                   change.addressId, tx.value,
+                  tx.message.has_value()
+                      ? nonstd::optional<common::crypto::Message>(
+                            tx.message.value())
+                      : nonstd::nullopt,
                   db::UserAddressBalanceReason::DEPOSIT, tail, {});
             }
           }

--- a/hub/service/user_address_monitor.h
+++ b/hub/service/user_address_monitor.h
@@ -9,9 +9,11 @@
 #define HUB_SERVICE_USER_ADDRESS_MONITOR_H_
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "cppclient/api.h"
@@ -26,6 +28,17 @@ namespace service {
 class UserAddressMonitor : public AddressMonitor {
  public:
   using AddressMonitor::AddressMonitor;
+
+  /// constructor
+  /// @param[in] api - an cppclient::IotaAPI compliant API provider
+  /// @param[in] interval - the tick interval, in milliseconds,
+  /// @param[in] fetchTransactionMessage - Should service fetch transaction's
+  /// message
+  explicit UserAddressMonitor(std::shared_ptr<cppclient::IotaAPI> api,
+                              std::chrono::milliseconds interval,
+                              bool fetchTransactionMessage)
+      : AddressMonitor(std::move(api), interval),
+        _fetchTransactionMessage(fetchTransactionMessage) {}
 
   std::vector<std::tuple<uint64_t, std::string>> monitoredAddresses() override;
   /// Process addresses that have changes
@@ -48,6 +61,9 @@ class UserAddressMonitor : public AddressMonitor {
   /// @return bool - true if balance valid for this address
   bool validateBalanceIsConsistent(const std::string& address,
                                    uint64_t addressId);
+
+ private:
+  bool _fetchTransactionMessage;
 };
 
 }  // namespace service

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -214,6 +214,7 @@ message UserAddressBalanceEvent {
   // Bundle hash of sweep (if reason == SWEEP)
   string hash      = 5;
   uint64 timestamp = 6;
+  string message = 7;
 }
 
 message HubAddressBalanceEvent {

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -74,6 +74,7 @@ CREATE TABLE IF NOT EXISTS user_address_balance (
   tail_hash CHAR(81) DEFAULT NULL,
   -- nullable if not swept yet
   sweep INTEGER DEFAULT NULL,
+  message TEXT(2187) DEFAULT NULL,
   occured_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT uab_reason_amount CHECK ((reason = 0 and tail_hash is not null and amount > 0) or (reason = 1 and sweep is not null and amount < 0)),
   CONSTRAINT uab_reason_range CHECK ((reason = 0 or reason = 1)),


### PR DESCRIPTION
# Description

Store message of transaction in user_address_balance table, messages that are stored are only those who belong to addresses generated by getDepositAddress command, meaning, when the _user_address_monitor_ detect such address has a balance it will store it's message (if configured) alongside it's value 

Fixes #237 

## Type of change

- Breaking change - Requires recreating db from schema file
- Documentation Fix

# How Has This Been Tested?




# Checklist:

_Please delete items that are not relevant._

- [ ] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
