### PR TITLE
GRPC API - recover funds endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ See [Getting Started](docs/getting_started.md) for information on how to use the
     -sweep_max_withdraw (Maximum number of withdraw requests to service per
       sweep.) type: uint32 default: 7
       
+  Flags from hub/server/grpc.cc:
+    -SignBundle_enabled (Whether the SignBundle API call should be available) 
+      type: bool (--SignBundle_enabled or --noSignBundle_enabled)
+       
+    -RecoverFunds_enabled (Whether the RecoverFunds API call should be available) 
+      type: bool (--RecoverFunds_enabled or --noRecoverFunds_enabled)
+      
 ```
 
 ## Useful things

--- a/hub/bundle/BUILD
+++ b/hub/bundle/BUILD
@@ -1,0 +1,13 @@
+cc_library(
+    name = "bundle_utils",
+    srcs = ["bundle_utils.cc"],
+    hdrs = ["bundle_utils.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//common/crypto",
+        "//hub/db",
+        "@com_github_gflags_gflags//:gflags",
+        "@com_github_google_glog//:glog",
+        "@iota_lib_cpp",
+    ],
+)

--- a/hub/bundle/bundle_utils.cc
+++ b/hub/bundle/bundle_utils.cc
@@ -42,7 +42,7 @@ std::tuple<common::crypto::Hash, std::string> createBundle(
     const std::vector<db::TransferInput>& deposits,
     const std::vector<db::TransferInput>& hubInputs,
     const std::vector<db::TransferOutput>& withdrawals,
-    const db::TransferOutput& hubOutput) {
+    const nonstd::optional<db::TransferOutput> hubOutputOptional) {
   auto& cryptoProvider = common::crypto::CryptoManager::get().provider();
 
   // 5.1. Generate bundle_utils hash & transactions
@@ -88,12 +88,14 @@ std::tuple<common::crypto::Hash, std::string> createBundle(
     }
 
     // output: hubOutput
-    IOTA::Models::Transaction tx;
-    tx.setAddress(hubOutput.payoutAddress.str());
-    tx.setTimestamp(timestamp);
-    tx.setValue(hubOutput.amount);
+    if (hubOutputOptional) {
+      IOTA::Models::Transaction tx;
+      tx.setAddress(hubOutputOptional->payoutAddress.str());
+      tx.setTimestamp(timestamp);
+      tx.setValue(hubOutputOptional->amount);
 
-    bundle.addTransaction(tx, 1);
+      bundle.addTransaction(tx, 1);
+    }
   }
 
   bundle.finalize();

--- a/hub/bundle/bundle_utils.cc
+++ b/hub/bundle/bundle_utils.cc
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2018 IOTA Stiftung
+ * https://github.com/iotaledger/rpchub
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#include "hub/bundle/bundle_utils.h"
+
+#include <chrono>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include <iota/models/bundle.hpp>
+#include <iota/models/transaction.hpp>
+
+#include "common/crypto/manager.h"
+#include "common/crypto/provider_base.h"
+#include "common/crypto/types.h"
+#include "hub/db/db.h"
+#include "hub/db/helper.h"
+
+namespace {
+constexpr size_t FRAGMENT_LEN = 2187;
+const std::string EMPTY_FRAG(FRAGMENT_LEN, '9');
+const std::string EMPTY_NONCE(27, '9');
+const std::string EMPTY_HASH(81, '9');
+}  // namespace
+
+namespace hub {
+namespace bundle_utils {
+
+std::tuple<common::crypto::Hash, std::string> createBundle(
+    const std::vector<db::TransferInput>& deposits,
+    const std::vector<db::TransferInput>& hubInputs,
+    const std::vector<db::TransferOutput>& withdrawals,
+    const db::TransferOutput& hubOutput) {
+  auto& cryptoProvider = common::crypto::CryptoManager::get().provider();
+
+  // 5.1. Generate bundle_utils hash & transactions
+  IOTA::Models::Bundle bundle;
+  {
+    // timestamp.
+    auto timestamp = std::chrono::duration_cast<std::chrono::seconds>(
+                         std::chrono::system_clock::now().time_since_epoch())
+                         .count();
+
+    // inputs: deposits
+    for (const auto& deposit : deposits) {
+      IOTA::Models::Transaction tx;
+      tx.setAddress(deposit.address.str());
+      tx.setTimestamp(timestamp);
+      tx.setValue((-1uLL) * deposit.amount);
+
+      bundle.addTransaction(tx,
+                            cryptoProvider.securityLevel(deposit.uuid).value());
+    }
+    // inputs: hubInputs
+    for (const auto& input : hubInputs) {
+      IOTA::Models::Transaction tx;
+      tx.setAddress(input.address.str());
+      tx.setTimestamp(timestamp);
+      tx.setValue((-1uLL) * input.amount);
+
+      bundle.addTransaction(tx,
+                            cryptoProvider.securityLevel(input.uuid).value());
+    }
+    // outputs: withdrawals
+    for (const auto& wd : withdrawals) {
+      IOTA::Models::Transaction tx;
+      tx.setAddress(wd.payoutAddress.str());
+      tx.setTimestamp(timestamp);
+      tx.setValue(wd.amount);
+
+      if (wd.tag) {
+        tx.setObsoleteTag(wd.tag->str());
+      }
+
+      bundle.addTransaction(tx, 1);
+    }
+
+    // output: hubOutput
+    IOTA::Models::Transaction tx;
+    tx.setAddress(hubOutput.payoutAddress.str());
+    tx.setTimestamp(timestamp);
+    tx.setValue(hubOutput.amount);
+
+    bundle.addTransaction(tx, 1);
+  }
+
+  bundle.finalize();
+
+  common::crypto::Hash bundleHash(bundle.getHash());
+
+  // 5.2 Generate signatures
+  std::unordered_map<common::crypto::Address, std::string> signaturesForAddress;
+
+  for (const auto& in : deposits) {
+    signaturesForAddress[in.address] =
+        cryptoProvider.getSignatureForUUID(in.uuid, bundleHash).value();
+  }
+  for (const auto& in : hubInputs) {
+    signaturesForAddress[in.address] =
+        cryptoProvider.getSignatureForUUID(in.uuid, bundleHash).value();
+  }
+
+  auto it = bundle.getTransactions().begin();
+
+  while (it != bundle.getTransactions().end()) {
+    auto& tx = *it;
+
+    if (tx.getValue() >= 0) {
+      tx.setSignatureFragments(EMPTY_FRAG);
+      tx.setNonce(EMPTY_NONCE);
+      tx.setTrunkTransaction(EMPTY_HASH);
+      tx.setBranchTransaction(EMPTY_HASH);
+
+      if (tx.getObsoleteTag().empty()) {
+        tx.setObsoleteTag(EMPTY_NONCE);
+      }
+
+      ++it;
+      continue;
+    }
+
+    std::string_view signature = signaturesForAddress.at(
+        common::crypto::Address(tx.getAddress().toTrytes()));
+
+    while (!signature.empty()) {
+      (*it).setSignatureFragments(
+          std::string(signature.substr(0, FRAGMENT_LEN)));
+      (*it).setNonce(EMPTY_NONCE);
+      (*it).setTrunkTransaction(EMPTY_HASH);
+      (*it).setBranchTransaction(EMPTY_HASH);
+
+      signature.remove_prefix(FRAGMENT_LEN);
+
+      ++it;
+    }
+  }
+
+  std::ostringstream bundleTrytesOS;
+  for (const auto& tx : bundle.getTransactions()) {
+    bundleTrytesOS << tx.toTrytes();
+  }
+
+  return {std::move(bundleHash), bundleTrytesOS.str()};
+}
+
+db::TransferOutput getHubOutput(uint64_t remainder) {
+  auto& dbConnection = db::DBManager::get().connection();
+  auto& cryptoProvider = common::crypto::CryptoManager::get().provider();
+
+  common::crypto::UUID hubOutputUUID;
+  auto address = cryptoProvider.getAddressForUUID(hubOutputUUID).value();
+
+  return {dbConnection.createHubAddress(hubOutputUUID, address),
+          remainder,
+          {},
+          std::move(address)};
+}
+
+}  // namespace bundle_utils
+}  // namespace hub

--- a/hub/bundle/bundle_utils.cc
+++ b/hub/bundle/bundle_utils.cc
@@ -157,18 +157,5 @@ std::tuple<common::crypto::Hash, std::string> createBundle(
   return {std::move(bundleHash), bundleTrytesOS.str()};
 }
 
-db::TransferOutput getHubOutput(uint64_t remainder) {
-  auto& dbConnection = db::DBManager::get().connection();
-  auto& cryptoProvider = common::crypto::CryptoManager::get().provider();
-
-  common::crypto::UUID hubOutputUUID;
-  auto address = cryptoProvider.getAddressForUUID(hubOutputUUID).value();
-
-  return {dbConnection.createHubAddress(hubOutputUUID, address),
-          remainder,
-          {},
-          std::move(address)};
-}
-
 }  // namespace bundle_utils
 }  // namespace hub

--- a/hub/bundle/bundle_utils.cc
+++ b/hub/bundle/bundle_utils.cc
@@ -42,7 +42,8 @@ std::tuple<common::crypto::Hash, std::string> createBundle(
     const std::vector<db::TransferInput>& deposits,
     const std::vector<db::TransferInput>& hubInputs,
     const std::vector<db::TransferOutput>& withdrawals,
-    const nonstd::optional<db::TransferOutput> hubOutputOptional) {
+    const nonstd::optional<db::TransferOutput> hubOutputOptional,
+    bool recoverFunds) {
   auto& cryptoProvider = common::crypto::CryptoManager::get().provider();
 
   // 5.1. Generate bundle_utils hash & transactions
@@ -106,8 +107,12 @@ std::tuple<common::crypto::Hash, std::string> createBundle(
   std::unordered_map<common::crypto::Address, std::string> signaturesForAddress;
 
   for (const auto& in : deposits) {
-    signaturesForAddress[in.address] =
-        cryptoProvider.getSignatureForUUID(in.uuid, bundleHash).value();
+    if (recoverFunds){
+        signaturesForAddress[in.address] = cryptoProvider.forceGetSignatureForUUID(in.uuid, bundleHash).value();
+    }else{
+        signaturesForAddress[in.address] =
+                cryptoProvider.getSignatureForUUID(in.uuid, bundleHash).value();
+    }
   }
   for (const auto& in : hubInputs) {
     signaturesForAddress[in.address] =

--- a/hub/bundle/bundle_utils.h
+++ b/hub/bundle/bundle_utils.h
@@ -27,6 +27,8 @@ namespace bundle_utils {
 /// @param[in] hubInputs - a list of internal transfers
 /// @param[in] withdrawals - a list of withdrawal transactions
 /// @param[in] hubOutput - a list of db::TransferOutput structures
+/// @param[in] recoverFunds - if true, this means we should force signature over
+/// an already spent address
 /// @return a std::tuple containing
 /// - the bundle hash
 /// - the serialized bundle
@@ -34,7 +36,8 @@ std::tuple<common::crypto::Hash, std::string> createBundle(
     const std::vector<db::TransferInput>& deposits,
     const std::vector<db::TransferInput>& hubInputs,
     const std::vector<db::TransferOutput>& withdrawals,
-    const nonstd::optional<db::TransferOutput> hubOutputOptional);
+    const nonstd::optional<db::TransferOutput> hubOutputOptional,
+    bool recoverFunds = false);
 
 }  // namespace bundle_utils
 }  // namespace hub

--- a/hub/bundle/bundle_utils.h
+++ b/hub/bundle/bundle_utils.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/rpchub
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#ifndef HUB_BUNDLE_CREATE_BUNDLE_H_
+#define HUB_BUNDLE_CREATE_BUNDLE_H_
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "common/crypto/types.h"
+#include "hub/db/types.h"
+
+namespace hub {
+    namespace bundle_utils {
+
+            /// Compute and serialize a bundle made up of all the deposits and withdrawals
+            /// identified during the sweep.
+            /// @param[in] deposits - a list of deposit transactions
+            /// @param[in] hubInputs - a list of internal transfers
+            /// @param[in] withdrawals - a list of withdrawal transactions
+            /// @param[in] hubOutput - a list of db::TransferOutput structures
+            /// @return a std::tuple containing
+            /// - the bundle hash
+            /// - the serialized bundle
+            std::tuple<common::crypto::Hash, std::string> createBundle(
+                    const std::vector<db::TransferInput>& deposits,
+                    const std::vector<db::TransferInput>& hubInputs,
+                    const std::vector<db::TransferOutput>& withdrawals,
+                    const db::TransferOutput& hubOutput);
+
+
+        /// Creates a new hub address to which funds that remain after a transfer
+        /// can be moved.
+        /// @param[in] remainder
+        /// @return a db::TransferOutput structure containing
+        /// - the new hub address
+        /// - the id of the new hub address
+        /// - the remainder
+        db::TransferOutput getHubOutput(uint64_t remainder);
+
+
+    }  // namespace bundle_utils
+}  // namespace hub
+
+#endif  // HUB_BUNDLE_CREATE_BUNDLE_H_

--- a/hub/bundle/bundle_utils.h
+++ b/hub/bundle/bundle_utils.h
@@ -36,15 +36,6 @@ std::tuple<common::crypto::Hash, std::string> createBundle(
     const std::vector<db::TransferOutput>& withdrawals,
     const nonstd::optional<db::TransferOutput> hubOutputOptional);
 
-/// Creates a new hub address to which funds that remain after a transfer
-/// can be moved.
-/// @param[in] remainder
-/// @return a db::TransferOutput structure containing
-/// - the new hub address
-/// - the id of the new hub address
-/// - the remainder
-db::TransferOutput getHubOutput(uint64_t remainder);
-
 }  // namespace bundle_utils
 }  // namespace hub
 

--- a/hub/bundle/bundle_utils.h
+++ b/hub/bundle/bundle_utils.h
@@ -19,35 +19,33 @@
 #include "hub/db/types.h"
 
 namespace hub {
-    namespace bundle_utils {
+namespace bundle_utils {
 
-            /// Compute and serialize a bundle made up of all the deposits and withdrawals
-            /// identified during the sweep.
-            /// @param[in] deposits - a list of deposit transactions
-            /// @param[in] hubInputs - a list of internal transfers
-            /// @param[in] withdrawals - a list of withdrawal transactions
-            /// @param[in] hubOutput - a list of db::TransferOutput structures
-            /// @return a std::tuple containing
-            /// - the bundle hash
-            /// - the serialized bundle
-            std::tuple<common::crypto::Hash, std::string> createBundle(
-                    const std::vector<db::TransferInput>& deposits,
-                    const std::vector<db::TransferInput>& hubInputs,
-                    const std::vector<db::TransferOutput>& withdrawals,
-                    const db::TransferOutput& hubOutput);
+/// Compute and serialize a bundle made up of all the deposits and withdrawals
+/// identified during the sweep.
+/// @param[in] deposits - a list of deposit transactions
+/// @param[in] hubInputs - a list of internal transfers
+/// @param[in] withdrawals - a list of withdrawal transactions
+/// @param[in] hubOutput - a list of db::TransferOutput structures
+/// @return a std::tuple containing
+/// - the bundle hash
+/// - the serialized bundle
+std::tuple<common::crypto::Hash, std::string> createBundle(
+    const std::vector<db::TransferInput>& deposits,
+    const std::vector<db::TransferInput>& hubInputs,
+    const std::vector<db::TransferOutput>& withdrawals,
+    const nonstd::optional<db::TransferOutput> hubOutputOptional);
 
+/// Creates a new hub address to which funds that remain after a transfer
+/// can be moved.
+/// @param[in] remainder
+/// @return a db::TransferOutput structure containing
+/// - the new hub address
+/// - the id of the new hub address
+/// - the remainder
+db::TransferOutput getHubOutput(uint64_t remainder);
 
-        /// Creates a new hub address to which funds that remain after a transfer
-        /// can be moved.
-        /// @param[in] remainder
-        /// @return a db::TransferOutput structure containing
-        /// - the new hub address
-        /// - the id of the new hub address
-        /// - the remainder
-        db::TransferOutput getHubOutput(uint64_t remainder);
-
-
-    }  // namespace bundle_utils
+}  // namespace bundle_utils
 }  // namespace hub
 
 #endif  // HUB_BUNDLE_CREATE_BUNDLE_H_

--- a/hub/commands/BUILD
+++ b/hub/commands/BUILD
@@ -31,6 +31,7 @@ cc_library(
         "//common/stats",
         "//hub/auth:hmac_provider",
         "//hub/db",
+        "//hub/bundle:bundle_utils",
         "//proto:hub_grpc_cc",
         "@boost//:range",
         "@com_github_google_glog//:glog",

--- a/hub/commands/helper.h
+++ b/hub/commands/helper.h
@@ -18,7 +18,7 @@ namespace cmd {
 std::string errorToString(const hub::rpc::ErrorCode& e);
 
 bool isAddressValid(std::string_view sv);
-}
+}  // namespace cmd
 }  // namespace hub
 
 #endif  // HUB_COMMANDS_HELPER_H_

--- a/hub/commands/recover_funds.h
+++ b/hub/commands/recover_funds.h
@@ -21,7 +21,7 @@ class RecoverFundsReply;
 
 namespace cmd {
 
-/// REcover funds from an already spent address into an output address
+/// Recover funds from an already spent address into an output address
 /// @param[in] hub::rpc::RecoverFundsRequest
 /// @param[in] hub::rpc::RecoverFundsReply
 class RecoverFunds : public common::Command<hub::rpc::RecoverFundsRequest,

--- a/hub/commands/recover_funds.h
+++ b/hub/commands/recover_funds.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/rpchub
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#ifndef HUB_COMMANDS_RECOVER_FUNDS_H_
+#define HUB_COMMANDS_RECOVER_FUNDS_H_
+
+#include <string>
+
+#include "common/command.h"
+#include "cppclient/api.h"
+
+namespace hub {
+    namespace rpc {
+        class RecoverFundsRequest;
+        class RecoverFundsReply;
+    }  // namespace rpc
+
+    namespace cmd {
+
+/// REcover funds from an already spent address into an output address
+/// @param[in] hub::rpc::RecoverFundsRequest
+/// @param[in] hub::rpc::RecoverFundsReply
+        class RecoverFunds : public common::Command<hub::rpc::RecoverFundsRequest,
+                hub::rpc::RecoverFundsReply> {
+        public:
+            using Command<hub::rpc::RecoverFundsRequest,
+                    hub::rpc::RecoverFundsReply>::Command;
+
+            explicit RecoverFunds(std::shared_ptr<common::ClientSession> session,
+            std::shared_ptr<cppclient::IotaAPI> api)
+            : Command(std::move(session)), _api(std::move(api)) {}
+
+            const std::string name() override { return "RecoverFunds"; }
+
+            grpc::Status doProcess(const hub::rpc::RecoverFundsRequest* request,
+                                   hub::rpc::RecoverFundsReply* response) noexcept override;
+
+        private:
+            std::shared_ptr<cppclient::IotaAPI> _api;
+        };
+    }  // namespace cmd
+}  // namespace hub
+
+#endif  // HUB_COMMANDS_RECOVER_FUNDS_H_

--- a/hub/commands/recover_funds.h
+++ b/hub/commands/recover_funds.h
@@ -14,35 +14,36 @@
 #include "cppclient/api.h"
 
 namespace hub {
-    namespace rpc {
-        class RecoverFundsRequest;
-        class RecoverFundsReply;
-    }  // namespace rpc
+namespace rpc {
+class RecoverFundsRequest;
+class RecoverFundsReply;
+}  // namespace rpc
 
-    namespace cmd {
+namespace cmd {
 
 /// REcover funds from an already spent address into an output address
 /// @param[in] hub::rpc::RecoverFundsRequest
 /// @param[in] hub::rpc::RecoverFundsReply
-        class RecoverFunds : public common::Command<hub::rpc::RecoverFundsRequest,
-                hub::rpc::RecoverFundsReply> {
-        public:
-            using Command<hub::rpc::RecoverFundsRequest,
-                    hub::rpc::RecoverFundsReply>::Command;
+class RecoverFunds : public common::Command<hub::rpc::RecoverFundsRequest,
+                                            hub::rpc::RecoverFundsReply> {
+ public:
+  using Command<hub::rpc::RecoverFundsRequest,
+                hub::rpc::RecoverFundsReply>::Command;
 
-            explicit RecoverFunds(std::shared_ptr<common::ClientSession> session,
-            std::shared_ptr<cppclient::IotaAPI> api)
-            : Command(std::move(session)), _api(std::move(api)) {}
+  explicit RecoverFunds(std::shared_ptr<common::ClientSession> session,
+                        std::shared_ptr<cppclient::IotaAPI> api)
+      : Command(std::move(session)), _api(std::move(api)) {}
 
-            const std::string name() override { return "RecoverFunds"; }
+  const std::string name() override { return "RecoverFunds"; }
 
-            grpc::Status doProcess(const hub::rpc::RecoverFundsRequest* request,
-                                   hub::rpc::RecoverFundsReply* response) noexcept override;
+  grpc::Status doProcess(
+      const hub::rpc::RecoverFundsRequest* request,
+      hub::rpc::RecoverFundsReply* response) noexcept override;
 
-        private:
-            std::shared_ptr<cppclient::IotaAPI> _api;
-        };
-    }  // namespace cmd
+ private:
+  std::shared_ptr<cppclient::IotaAPI> _api;
+};
+}  // namespace cmd
 }  // namespace hub
 
 #endif  // HUB_COMMANDS_RECOVER_FUNDS_H_

--- a/hub/commands/reocver_funds.cc
+++ b/hub/commands/reocver_funds.cc
@@ -120,8 +120,6 @@ grpc::Status RecoverFunds::doProcess(
                                  amount};
     deposits.push_back(std::move(ti));
 
-    auto hubOutput = hub::bundle_utils::getHubOutput(0);
-
     std::vector<hub::db::TransferOutput> outputs;
 
     // Create the "withdrawl"

--- a/hub/commands/reocver_funds.cc
+++ b/hub/commands/reocver_funds.cc
@@ -119,7 +119,7 @@ grpc::Status RecoverFunds::doProcess(
 
     hub::db::TransferInput ti = {maybeAddressInfo.value().id, userId,
                                  address.value(), maybeAddressInfo.value().uuid,
-                                 -amount};
+                                 amount};
     deposits.push_back(std::move(ti));
 
     auto hubOutput = hub::bundle_utils::getHubOutput(0);

--- a/hub/commands/reocver_funds.cc
+++ b/hub/commands/reocver_funds.cc
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2018 IOTA Stiftung
+ * https://github.com/iotaledger/rpchub
+ *
+ * Refer to the LICENSE file for licensing Secretrmation
+ */
+
+#include "hub/commands/recover_funds.h"
+
+#include <cstdint>
+#include <utility>
+
+#include <sqlpp11/exception.h>
+
+#include "common/crypto/manager.h"
+#include "common/crypto/types.h"
+#include "common/stats/session.h"
+#include "hub/auth/manager.h"
+#include "hub/bundle/bundle_utils.h"
+#include "hub/commands/helper.h"
+#include "hub/db/db.h"
+#include "hub/db/helper.h"
+#include "hub/db/types.h"
+#include "proto/hub.pb.h"
+#include "schema/schema.h"
+
+namespace hub {
+namespace cmd {
+
+grpc::Status RecoverFunds::doProcess(
+    const hub::rpc::RecoverFundsRequest* request,
+    hub::rpc::RecoverFundsReply* response) noexcept {
+  auto& connection = db::DBManager::get().connection();
+  auto& cryptoProvider = common::crypto::CryptoManager::get().provider();
+  auto& authProvider = auth::AuthManager::get().provider();
+
+  try {
+    uint64_t userId;
+
+    // Get userId for identifier
+    {
+      auto maybeUserId = connection.userIdFromIdentifier(request->userid());
+      if (!maybeUserId) {
+        return grpc::Status(
+            grpc::StatusCode::FAILED_PRECONDITION, "",
+            errorToString(hub::rpc::ErrorCode::USER_DOES_NOT_EXIST));
+      }
+
+      userId = maybeUserId.value();
+    }
+
+    nonstd::optional<common::crypto::Address> address = {
+        common::crypto::Address(request->address())};
+    nonstd::optional<common::crypto::Address> payoutAddress;
+
+    if (request->validatechecksum()) {
+      payoutAddress =
+          std::move(common::crypto::CryptoManager::get()
+                        .provider()
+                        .verifyAndStripChecksum(request->payoutaddress()));
+
+      if (!payoutAddress.has_value()) {
+        return grpc::Status(
+            grpc::StatusCode::FAILED_PRECONDITION, "",
+            errorToString(hub::rpc::ErrorCode::CHECKSUM_INVALID));
+      }
+    } else {
+      payoutAddress = {common::crypto::Address(request->payoutaddress())};
+    }
+
+    // 1. Check that address was used before
+    auto maybeAddressInfo = connection.getAddressInfo(address.value());
+    if (!maybeAddressInfo) {
+      return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "",
+                          errorToString(hub::rpc::ErrorCode::UNKNOWN_ADDRESS));
+    }
+
+    if (maybeAddressInfo->userId.compare(request->userid()) != 0) {
+      return grpc::Status(
+          grpc::StatusCode::FAILED_PRECONDITION, "",
+          errorToString(hub::rpc::ErrorCode::WRONG_USER_ADDRESS));
+    }
+
+    if (!maybeAddressInfo->usedForSweep) {
+      return grpc::Status(
+          grpc::StatusCode::FAILED_PRECONDITION, "",
+          errorToString(hub::rpc::ErrorCode::INELIGIBLE_ADDRESS));
+    }
+
+    // Verify payout address wasn't spent before
+    if (_api) {
+      auto res = _api->wereAddressesSpentFrom({payoutAddress.value().str()});
+      if (!res.has_value() || res.value().states.empty()) {
+        return grpc::Status(
+            grpc::StatusCode::FAILED_PRECONDITION, "",
+            errorToString(hub::rpc::ErrorCode::IRI_CLIENT_UNAVAILABLE));
+      } else if (res.value().states.front()) {
+        return grpc::Status(
+            grpc::StatusCode::FAILED_PRECONDITION, "",
+            errorToString(hub::rpc::ErrorCode::ADDRESS_WAS_ALREADY_SPENT));
+      }
+    }
+
+    const auto& iriBalances = _api->getBalances({request->address()});
+    if (!iriBalances) {
+      return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "",
+                          errorToString(hub::rpc::ErrorCode::UNKNOWN_ADDRESS));
+    }
+
+    auto amount = iriBalances.value().at(request->address());
+
+    if (amount == 0) {
+      return grpc::Status(
+          grpc::StatusCode::FAILED_PRECONDITION, "",
+          errorToString(hub::rpc::ErrorCode::ADDRESS_BALANCE_ZERO));
+    }
+
+    std::vector<hub::db::TransferInput> deposits;
+
+    hub::db::TransferInput ti = {maybeAddressInfo.value().id, userId,
+                                 address.value(), maybeAddressInfo.value().uuid,
+                                 -amount};
+    deposits.push_back(std::move(ti));
+
+    auto hubOutput = hub::bundle_utils::getHubOutput(0);
+
+    std::vector<hub::db::TransferOutput> outputs;
+
+    // Create the "withdrawl"
+    outputs.emplace_back(
+        hub::db::TransferOutput{-1, amount, {}, payoutAddress.value()});
+
+    auto bundle =
+        hub::bundle_utils::createBundle(deposits, {}, outputs, hubOutput);
+
+    connection.createSweep(std::get<0>(bundle), std::get<1>(bundle),
+                           hubOutput.id);
+
+  } catch (const std::exception& ex) {
+    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "",
+                        errorToString(hub::rpc::ErrorCode::EC_UNKNOWN));
+  }
+
+  return grpc::Status::OK;
+}
+
+}  // namespace cmd
+}  // namespace hub

--- a/hub/commands/was_address_spent_from.h
+++ b/hub/commands/was_address_spent_from.h
@@ -17,36 +17,37 @@
 #include "cppclient/api.h"
 
 namespace hub {
-    namespace rpc {
-        class WasAddressSpentFromRequest;
-        class WasAddressSpentFromReply;
-    }  // namespace rpc
+namespace rpc {
+class WasAddressSpentFromRequest;
+class WasAddressSpentFromReply;
+}  // namespace rpc
 
-    namespace cmd {
+namespace cmd {
 
 /// Returns whether or not an address was spent.
 /// @param[in] hub::rpc::WasAddressSpentFromRequest
 /// @param[in] hub::rpc::WasAddressSpentFromReply
-        class WasAddressSpentFrom : public common::Command<hub::rpc::WasAddressSpentFromRequest,
-                hub::rpc::WasAddressSpentFromReply> {
-        public:
-            using Command<hub::rpc::WasAddressSpentFromRequest,
-                    hub::rpc::WasAddressSpentFromReply>::Command;
+class WasAddressSpentFrom
+    : public common::Command<hub::rpc::WasAddressSpentFromRequest,
+                             hub::rpc::WasAddressSpentFromReply> {
+ public:
+  using Command<hub::rpc::WasAddressSpentFromRequest,
+                hub::rpc::WasAddressSpentFromReply>::Command;
 
-            explicit WasAddressSpentFrom(std::shared_ptr<common::ClientSession> session,
-                                  std::shared_ptr<cppclient::IotaAPI> api)
-                    : Command(std::move(session)), _api(std::move(api)) {}
+  explicit WasAddressSpentFrom(std::shared_ptr<common::ClientSession> session,
+                               std::shared_ptr<cppclient::IotaAPI> api)
+      : Command(std::move(session)), _api(std::move(api)) {}
 
-            const std::string name() override { return "WasAddressSpentFrom"; }
+  const std::string name() override { return "WasAddressSpentFrom"; }
 
-            grpc::Status doProcess(
-                    const hub::rpc::WasAddressSpentFromRequest* request,
-                    hub::rpc::WasAddressSpentFromReply* response) noexcept override;
+  grpc::Status doProcess(
+      const hub::rpc::WasAddressSpentFromRequest* request,
+      hub::rpc::WasAddressSpentFromReply* response) noexcept override;
 
-        private:
-            std::shared_ptr<cppclient::IotaAPI> _api;
-        };
-    }  // namespace cmd
+ private:
+  std::shared_ptr<cppclient::IotaAPI> _api;
+};
+}  // namespace cmd
 }  // namespace hub
 
 #endif  // HUB_COMMANDS_WAS_ADDRESS_SPENT_FROM_H_

--- a/hub/commands/was_withdrawal_cancelled.h
+++ b/hub/commands/was_withdrawal_cancelled.h
@@ -13,31 +13,30 @@
 #include "common/command.h"
 
 namespace hub {
-    namespace rpc {
-        class WasWithdrawalCancelledRequest;
-        class WasWithdrawalCancelledReply;
-    }  // namespace rpc
+namespace rpc {
+class WasWithdrawalCancelledRequest;
+class WasWithdrawalCancelledReply;
+}  // namespace rpc
 
-    namespace cmd {
+namespace cmd {
 
+/// Returns true if withdrawal was cancelled
+/// @param[in] request - a rpc::WasWithdrawalCancelledRequest request
+/// @param[in] response - a rpc::WasWithdrawalCancelledResponse response
+class WasWithdrawalCancelled
+    : public common::Command<hub::rpc::WasWithdrawalCancelledRequest,
+                             hub::rpc::WasWithdrawalCancelledReply> {
+ public:
+  using Command<hub::rpc::WasWithdrawalCancelledRequest,
+                hub::rpc::WasWithdrawalCancelledReply>::Command;
 
-        /// Returns true if withdrawal was cancelled
-        /// @param[in] request - a rpc::WasWithdrawalCancelledRequest request
-        /// @param[in] response - a rpc::WasWithdrawalCancelledResponse response
-        class WasWithdrawalCancelled
-                : public common::Command<hub::rpc::WasWithdrawalCancelledRequest,
-                        hub::rpc::WasWithdrawalCancelledReply> {
-        public:
-            using Command<hub::rpc::WasWithdrawalCancelledRequest,
-                    hub::rpc::WasWithdrawalCancelledReply>::Command;
+  const std::string name() override { return "WasWithdrawalCancelled"; }
 
-            const std::string name() override { return "WasWithdrawalCancelled"; }
-
-            grpc::Status doProcess(
-                    const hub::rpc::WasWithdrawalCancelledRequest* request,
-                    hub::rpc::WasWithdrawalCancelledReply* response) noexcept override;
-        };
-    }  // namespace cmd
+  grpc::Status doProcess(
+      const hub::rpc::WasWithdrawalCancelledRequest* request,
+      hub::rpc::WasWithdrawalCancelledReply* response) noexcept override;
+};
+}  // namespace cmd
 }  // namespace hub
 
 #endif  // HUB_COMMANDS_WAS_WITHDRAWAL_CANCELLED_H_

--- a/hub/crypto/local_provider.cc
+++ b/hub/crypto/local_provider.cc
@@ -14,9 +14,7 @@ nonstd::optional<std::string> LocalSigningProvider::getSignatureForUUID(
     const common::crypto::Hash& bundleHash) const {
   auto& connection = db::DBManager::get().connection();
 
-  if (!connection.hasUUIDAlreadyBeenSigned(uuid)) {
-    connection.markUUIDAsSigned(uuid);
-  }
+  connection.markUUIDAsSigned(uuid);
 
   return doGetSignatureForUUID(uuid, bundleHash);
 }

--- a/hub/crypto/local_provider.cc
+++ b/hub/crypto/local_provider.cc
@@ -13,7 +13,10 @@ nonstd::optional<std::string> LocalSigningProvider::getSignatureForUUID(
     const common::crypto::UUID& uuid,
     const common::crypto::Hash& bundleHash) const {
   auto& connection = db::DBManager::get().connection();
-  connection.markUUIDAsSigned(uuid);
+
+  if (!connection.hasUUIDAlreadyBeenSigned(uuid)) {
+    connection.markUUIDAsSigned(uuid);
+  }
 
   return doGetSignatureForUUID(uuid, bundleHash);
 }

--- a/hub/db/connection.h
+++ b/hub/db/connection.h
@@ -135,6 +135,10 @@ class Connection {
   /// @param[in] uuid - the common::crypto::UUID to mark as signed
   virtual void markUUIDAsSigned(const common::crypto::UUID& uuid) = 0;
 
+  /// Checks if uuid was already signed
+  /// @param[in] uuid - the common::crypto::UUID to mark as signed
+  virtual bool hasUUIDAlreadyBeenSigned(const common::crypto::UUID& uuid) = 0;
+
   /// Get a list of account balances for a user
   /// @param[in] userId - the user id in the database
   /// @param[in] newerThan - the start point in time
@@ -306,7 +310,6 @@ class Connection {
   /// Provides the total amount of user funds currently managed by the Hub
   /// @return uint64_t - the total user account balance
   virtual uint64_t getTotalBalance() = 0;
-
 
  private:
   friend class DBManager;

--- a/hub/db/connection.h
+++ b/hub/db/connection.h
@@ -135,10 +135,6 @@ class Connection {
   /// @param[in] uuid - the common::crypto::UUID to mark as signed
   virtual void markUUIDAsSigned(const common::crypto::UUID& uuid) = 0;
 
-  /// Checks if uuid was already signed
-  /// @param[in] uuid - the common::crypto::UUID to mark as signed
-  virtual bool hasUUIDAlreadyBeenSigned(const common::crypto::UUID& uuid) = 0;
-
   /// Get a list of account balances for a user
   /// @param[in] userId - the user id in the database
   /// @param[in] newerThan - the start point in time

--- a/hub/db/connection_impl.h
+++ b/hub/db/connection_impl.h
@@ -149,6 +149,10 @@ class ConnectionImpl : public Connection {
     db::helper<Conn>::markTailAsConfirmed(*_conn, hash);
   }
 
+  bool hasUUIDAlreadyBeenSigned(const common::crypto::UUID& uuid) override {
+    return db::helper<Conn>::hasUUIDAlreadyBeenSigned(*_conn, uuid);
+  }
+
   std::vector<UserAccountBalanceEvent> getUserAccountBalances(
       uint64_t userId,
       std::chrono::system_clock::time_point newerThan) override {

--- a/hub/db/connection_impl.h
+++ b/hub/db/connection_impl.h
@@ -149,10 +149,6 @@ class ConnectionImpl : public Connection {
     db::helper<Conn>::markTailAsConfirmed(*_conn, hash);
   }
 
-  bool hasUUIDAlreadyBeenSigned(const common::crypto::UUID& uuid) override {
-    return db::helper<Conn>::hasUUIDAlreadyBeenSigned(*_conn, uuid);
-  }
-
   std::vector<UserAccountBalanceEvent> getUserAccountBalances(
       uint64_t userId,
       std::chrono::system_clock::time_point newerThan) override {

--- a/hub/db/helper.cc
+++ b/hub/db/helper.cc
@@ -224,6 +224,16 @@ void helper<C>::markUUIDAsSigned(C& connection,
 }
 
 template <typename C>
+bool helper<C>::hasUUIDAlreadyBeenSigned(C& connection,
+                                         const common::crypto::UUID& uuid) {
+  db::sql::SignedUuids tbl;
+
+  auto result =
+      connection(select(tbl.uuid).from(tbl).where(tbl.uuid <= uuid.str()));
+  return !result.empty();
+}
+
+template <typename C>
 std::vector<Sweep> helper<C>::getUnconfirmedSweeps(
     C& connection, const std::chrono::system_clock::time_point& olderThan) {
   db::sql::Sweep swp;

--- a/hub/db/helper.cc
+++ b/hub/db/helper.cc
@@ -223,15 +223,6 @@ void helper<C>::markUUIDAsSigned(C& connection,
   connection(insert_into(tbl).set(tbl.uuid = uuid.str()));
 }
 
-template <typename C>
-bool helper<C>::hasUUIDAlreadyBeenSigned(C& connection,
-                                         const common::crypto::UUID& uuid) {
-  db::sql::SignedUuids tbl;
-
-  auto result =
-      connection(select(tbl.uuid).from(tbl).where(tbl.uuid == (uuid.str())));
-  return !result.empty();
-}
 
 template <typename C>
 std::vector<Sweep> helper<C>::getUnconfirmedSweeps(

--- a/hub/db/helper.cc
+++ b/hub/db/helper.cc
@@ -229,7 +229,7 @@ bool helper<C>::hasUUIDAlreadyBeenSigned(C& connection,
   db::sql::SignedUuids tbl;
 
   auto result =
-      connection(select(tbl.uuid).from(tbl).where(tbl.uuid <= uuid.str()));
+      connection(select(tbl.uuid).from(tbl).where(tbl.uuid == (uuid.str())));
   return !result.empty();
 }
 

--- a/hub/db/helper.cc
+++ b/hub/db/helper.cc
@@ -811,7 +811,7 @@ nonstd::optional<AddressInfo> helper<C>::getAddressInfo(
 
   auto result = connection(
       select(
-          acc.identifier, add.seedUuid,
+          add.id, acc.identifier, add.seedUuid,
           exists(select(bal.id).from(bal).where(
               bal.userAddress == add.id &&
               bal.reason == static_cast<int>(UserAddressBalanceReason::SWEEP))))
@@ -822,7 +822,7 @@ nonstd::optional<AddressInfo> helper<C>::getAddressInfo(
     return {};
   } else {
     auto& front = result.front();
-    return {AddressInfo{std::move(front.identifier.value()),
+    return {AddressInfo{front.id, std::move(front.identifier.value()),
                         common::crypto::UUID(front.seedUuid.value()),
                         front.exists}};
   }

--- a/hub/db/helper.h
+++ b/hub/db/helper.h
@@ -61,6 +61,8 @@ struct helper {
   static nonstd::optional<AddressWithUUID> selectFirstUserAddress(
       C& connection);
   static void markUUIDAsSigned(C& connection, const common::crypto::UUID& uuid);
+  static bool hasUUIDAlreadyBeenSigned(C& connection,
+                                       const common::crypto::UUID& uuid);
   static std::vector<UserAccountBalanceEvent> getUserAccountBalances(
       C& connection, uint64_t userId,
       std::chrono::system_clock::time_point newerThan);

--- a/hub/db/helper.h
+++ b/hub/db/helper.h
@@ -61,8 +61,7 @@ struct helper {
   static nonstd::optional<AddressWithUUID> selectFirstUserAddress(
       C& connection);
   static void markUUIDAsSigned(C& connection, const common::crypto::UUID& uuid);
-  static bool hasUUIDAlreadyBeenSigned(C& connection,
-                                       const common::crypto::UUID& uuid);
+
   static std::vector<UserAccountBalanceEvent> getUserAccountBalances(
       C& connection, uint64_t userId,
       std::chrono::system_clock::time_point newerThan);

--- a/hub/db/types.h
+++ b/hub/db/types.h
@@ -117,6 +117,7 @@ struct TransferOutput {
 
 struct AddressInfo {
  public:
+  int64_t id;
   std::string userId;
   common::crypto::UUID uuid;
   bool usedForSweep;

--- a/hub/db/types.h
+++ b/hub/db/types.h
@@ -117,7 +117,7 @@ struct TransferOutput {
 
 struct AddressInfo {
  public:
-  int64_t id;
+  uint64_t id;
   std::string userId;
   common::crypto::UUID uuid;
   bool usedForSweep;

--- a/hub/iota/local_pow.cc
+++ b/hub/iota/local_pow.cc
@@ -19,8 +19,9 @@
 namespace hub {
 namespace iota {
 
-LocalPOW::LocalPOW(size_t depth, size_t mwm)
-    : POWProvider(nullptr, depth, mwm) {}
+LocalPOW::LocalPOW(std::shared_ptr<cppclient::IotaAPI> api, size_t depth,
+                   size_t mwm)
+    : POWProvider(api, depth, mwm) {}
 
 std::vector<std::string> LocalPOW::doPOW(const std::vector<std::string>& trytes,
                                          const std::string& trunk,

--- a/hub/iota/local_pow.h
+++ b/hub/iota/local_pow.h
@@ -23,7 +23,7 @@ class LocalPOW : public POWProvider {
  public:
   using POWProvider::POWProvider;
 
-  LocalPOW(size_t depth, size_t mwm);
+  LocalPOW(std::shared_ptr<cppclient::IotaAPI> api, size_t depth, size_t mwm);
 
   static constexpr uint16_t OBSOLETE_TAG_OFFSET = 2295;
   static constexpr uint16_t TIMESTAMP_OFFSET = 2322;

--- a/hub/server/grpc.cc
+++ b/hub/server/grpc.cc
@@ -24,6 +24,7 @@
 #include "hub/commands/get_stats.h"
 #include "hub/commands/get_user_history.h"
 #include "hub/commands/process_transfer_batch.h"
+#include "hub/commands/recover_funds.h"
 #include "hub/commands/sign_bundle.h"
 #include "hub/commands/sweep_detail.h"
 #include "hub/commands/sweep_info.h"
@@ -35,6 +36,9 @@
 
 DEFINE_bool(SignBundle_enabled, false,
             "Whether the SignBundle API call should be available");
+
+DEFINE_bool(RecoverFunds_enabled, false,
+            "Whether the RecoverFunds API call should be available");
 
 namespace hub {
 
@@ -180,6 +184,20 @@ grpc::Status HubImpl::WasAddressSpentFrom(
     hub::rpc::WasAddressSpentFromReply* response) {
   auto clientSession = std::make_shared<common::ClientSession>();
   cmd::WasAddressSpentFrom cmd(clientSession);
+  return cmd.process(request, response);
+}
+
+grpc::Status HubImpl::RecoverFunds(grpc::ServerContext* context,
+                                   const hub::rpc::RecoverFundsRequest* request,
+                                   hub::rpc::RecoverFundsReply* response) {
+  auto clientSession = std::make_shared<common::ClientSession>();
+
+  if (!FLAGS_RecoverFunds_enabled) {
+    LOG(ERROR) << clientSession << ": Recover funds is disabled";
+    return grpc::Status::CANCELLED;
+  }
+
+  cmd::RecoverFunds cmd(clientSession, _api);
   return cmd.process(request, response);
 }
 

--- a/hub/server/grpc.h
+++ b/hub/server/grpc.h
@@ -139,43 +139,39 @@ class HubImpl final : public hub::rpc::Hub::Service {
                         const hub::rpc::GetStatsRequest* request,
                         hub::rpc::GetStatsReply* response) override;
 
+  /// Returns true if withdrawal was cancelled
+  /// @param[in] context - server context
+  /// @param[in] request - a rpc::WasWithdrawalCancelledRequest request
+  /// @param[in] response - a rpc::WasWithdrawalCancelledResponse response
+  /// @return grpc::Status
 
-    /// Returns true if withdrawal was cancelled
-    /// @param[in] context - server context
-    /// @param[in] request - a rpc::WasWithdrawalCancelledRequest request
-    /// @param[in] response - a rpc::WasWithdrawalCancelledResponse response
-    /// @return grpc::Status
+  grpc::Status WasWithdrawalCancelled(
+      grpc::ServerContext* context,
+      const hub::rpc::WasWithdrawalCancelledRequest* request,
+      hub::rpc::WasWithdrawalCancelledReply* response) override;
 
-    grpc::Status WasWithdrawalCancelled(
-            grpc::ServerContext* context,
-            const hub::rpc::WasWithdrawalCancelledRequest* request,
-            hub::rpc::WasWithdrawalCancelledReply* response) override;
+  /// Returns true if address was spent from
+  /// @param[in] context - server context
+  /// @param[in] request - a rpc::wasAddressSpentFromRequest request
+  /// @param[in] response - a rpc::wasAddressSpentFromReply response
+  /// @return grpc::Status
 
-    /// Returns true if address was spent from
-    /// @param[in] context - server context
-    /// @param[in] request - a rpc::wasAddressSpentFromRequest request
-    /// @param[in] response - a rpc::wasAddressSpentFromReply response
-    /// @return grpc::Status
+  grpc::Status WasAddressSpentFrom(
+      grpc::ServerContext* context,
+      const hub::rpc::WasAddressSpentFromRequest* request,
+      hub::rpc::WasAddressSpentFromReply* response) override;
 
-    grpc::Status WasAddressSpentFrom(
-            grpc::ServerContext* context,
-            const hub::rpc::WasAddressSpentFromRequest* request,
-            hub::rpc::WasAddressSpentFromReply* response) override;
+  /// Recover funds from an already spent address
+  /// @param[in] context - server context
+  /// @param[in] request - a rpc::RecoverFundsRequest request
+  /// @param[in] response - a rpc::RecoverFundsReply response
+  /// @return grpc::Status
 
+  grpc::Status RecoverFunds(grpc::ServerContext* context,
+                            const hub::rpc::RecoverFundsRequest* request,
+                            hub::rpc::RecoverFundsReply* response) override;
 
-    /// Recover funds from an already spent address
-    /// @param[in] context - server context
-    /// @param[in] request - a rpc::RecoverFundsRequest request
-    /// @param[in] response - a rpc::RecoverFundsReply response
-    /// @return grpc::Status
-
-    grpc::Status RecoverFunds(
-            grpc::ServerContext* context,
-            const hub::rpc::RecoverFundsRequest* request,
-            hub::rpc::RecoverFundsReply* response) override;
-
-
-private:
+ private:
   std::shared_ptr<cppclient::IotaAPI> _api;
 };
 

--- a/hub/server/grpc.h
+++ b/hub/server/grpc.h
@@ -163,6 +163,18 @@ class HubImpl final : public hub::rpc::Hub::Service {
             hub::rpc::WasAddressSpentFromReply* response) override;
 
 
+    /// Recover funds from an already spent address
+    /// @param[in] context - server context
+    /// @param[in] request - a rpc::RecoverFundsRequest request
+    /// @param[in] response - a rpc::RecoverFundsReply response
+    /// @return grpc::Status
+
+    grpc::Status RecoverFunds(
+            grpc::ServerContext* context,
+            const hub::rpc::RecoverFundsRequest* request,
+            hub::rpc::RecoverFundsReply* response) override;
+
+
 private:
   std::shared_ptr<cppclient::IotaAPI> _api;
 };

--- a/hub/server/server.cc
+++ b/hub/server/server.cc
@@ -129,7 +129,7 @@ void HubServer::initialise() {
         _api, FLAGS_depth, FLAGS_minWeightMagnitude));
   } else if (FLAGS_powMode == "local") {
     iota::POWManager::get().setProvider(std::make_unique<iota::LocalPOW>(
-        FLAGS_depth, FLAGS_minWeightMagnitude));
+        _api, FLAGS_depth, FLAGS_minWeightMagnitude));
   } else {
     LOG(FATAL) << "PoW mode: \"" << FLAGS_powMode << "\" not recognized";
   }

--- a/hub/service/BUILD
+++ b/hub/service/BUILD
@@ -34,13 +34,9 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":scheduled_service",
-        "//common/crypto",
-        "//hub/db",
+        "//hub/bundle:bundle_utils",
         "@boost//:range",
         "@boost//:uuid",
-        "@com_github_gflags_gflags//:gflags",
-        "@com_github_google_glog//:glog",
-        "@iota_lib_cpp",
         "@org_iota_entangled//cppclient:beast",
     ],
 )

--- a/hub/service/sweep_service.cc
+++ b/hub/service/sweep_service.cc
@@ -137,8 +137,8 @@ bool SweepService::doTick() {
     LOG(INFO) << "Will move " << remainder
               << " into new Hub address: " << hubOutput.payoutAddress.str();
     // 5. Generate bundle_utils
-    auto bundle =
-        bundle_utils::createBundle(deposits, hubInputs, withdrawals, hubOutput);
+    auto bundle = bundle_utils::createBundle(deposits, hubInputs, withdrawals,
+                                             {hubOutput});
 
     // 6. Commit to DB
     persistToDatabase(bundle, deposits, hubInputs, withdrawals, hubOutput);

--- a/hub/service/sweep_service.cc
+++ b/hub/service/sweep_service.cc
@@ -27,6 +27,7 @@
 #include "common/crypto/manager.h"
 #include "common/crypto/provider_base.h"
 #include "common/crypto/types.h"
+#include "hub/bundle/bundle_utils.h"
 #include "hub/db/db.h"
 #include "hub/db/helper.h"
 
@@ -45,176 +46,6 @@ DEFINE_uint32(sweep_max_deposit, 5,
 
 namespace hub {
 namespace service {
-
-db::TransferOutput SweepService::getHubOutput(uint64_t remainder) {
-  auto& dbConnection = db::DBManager::get().connection();
-  auto& cryptoProvider = common::crypto::CryptoManager::get().provider();
-
-  common::crypto::UUID hubOutputUUID;
-  auto address = cryptoProvider.getAddressForUUID(hubOutputUUID).value();
-
-  return {dbConnection.createHubAddress(hubOutputUUID, address),
-          remainder,
-          {},
-          std::move(address)};
-}
-
-std::tuple<common::crypto::Hash, std::string> SweepService::createBundle(
-    const std::vector<db::TransferInput>& deposits,
-    const std::vector<db::TransferInput>& hubInputs,
-    const std::vector<db::TransferOutput>& withdrawals,
-    const db::TransferOutput& hubOutput) {
-  auto& cryptoProvider = common::crypto::CryptoManager::get().provider();
-
-  // 5.1. Generate bundle hash & transactions
-  IOTA::Models::Bundle bundle;
-  {
-    // timestamp.
-    auto timestamp = std::chrono::duration_cast<std::chrono::seconds>(
-                         std::chrono::system_clock::now().time_since_epoch())
-                         .count();
-
-    // inputs: deposits
-    for (const auto& deposit : deposits) {
-      IOTA::Models::Transaction tx;
-      tx.setAddress(deposit.address.str());
-      tx.setTimestamp(timestamp);
-      tx.setValue((-1uLL) * deposit.amount);
-
-      bundle.addTransaction(tx,
-                            cryptoProvider.securityLevel(deposit.uuid).value());
-    }
-    // inputs: hubInputs
-    for (const auto& input : hubInputs) {
-      IOTA::Models::Transaction tx;
-      tx.setAddress(input.address.str());
-      tx.setTimestamp(timestamp);
-      tx.setValue((-1uLL) * input.amount);
-
-      bundle.addTransaction(tx,
-                            cryptoProvider.securityLevel(input.uuid).value());
-    }
-    // outputs: withdrawals
-    for (const auto& wd : withdrawals) {
-      IOTA::Models::Transaction tx;
-      tx.setAddress(wd.payoutAddress.str());
-      tx.setTimestamp(timestamp);
-      tx.setValue(wd.amount);
-
-      if (wd.tag) {
-        tx.setObsoleteTag(wd.tag->str());
-      }
-
-      bundle.addTransaction(tx, 1);
-    }
-
-    // output: hubOutput
-    IOTA::Models::Transaction tx;
-    tx.setAddress(hubOutput.payoutAddress.str());
-    tx.setTimestamp(timestamp);
-    tx.setValue(hubOutput.amount);
-
-    bundle.addTransaction(tx, 1);
-  }
-
-  bundle.finalize();
-
-  common::crypto::Hash bundleHash(bundle.getHash());
-
-  // 5.2 Generate signatures
-  std::unordered_map<common::crypto::Address, std::string> signaturesForAddress;
-
-  for (const auto& in : deposits) {
-    signaturesForAddress[in.address] =
-        cryptoProvider.getSignatureForUUID(in.uuid, bundleHash).value();
-  }
-  for (const auto& in : hubInputs) {
-    signaturesForAddress[in.address] =
-        cryptoProvider.getSignatureForUUID(in.uuid, bundleHash).value();
-  }
-
-  auto it = bundle.getTransactions().begin();
-
-  while (it != bundle.getTransactions().end()) {
-    auto& tx = *it;
-
-    if (tx.getValue() >= 0) {
-      tx.setSignatureFragments(EMPTY_FRAG);
-      tx.setNonce(EMPTY_NONCE);
-      tx.setTrunkTransaction(EMPTY_HASH);
-      tx.setBranchTransaction(EMPTY_HASH);
-
-      if (tx.getObsoleteTag().empty()) {
-        tx.setObsoleteTag(EMPTY_NONCE);
-      }
-
-      ++it;
-      continue;
-    }
-
-    std::string_view signature = signaturesForAddress.at(
-        common::crypto::Address(tx.getAddress().toTrytes()));
-
-    while (!signature.empty()) {
-      (*it).setSignatureFragments(
-          std::string(signature.substr(0, FRAGMENT_LEN)));
-      (*it).setNonce(EMPTY_NONCE);
-      (*it).setTrunkTransaction(EMPTY_HASH);
-      (*it).setBranchTransaction(EMPTY_HASH);
-
-      signature.remove_prefix(FRAGMENT_LEN);
-
-      ++it;
-    }
-  }
-
-  std::ostringstream bundleTrytesOS;
-  for (const auto& tx : bundle.getTransactions()) {
-    bundleTrytesOS << tx.toTrytes();
-  }
-
-  return {std::move(bundleHash), bundleTrytesOS.str()};
-}
-
-void SweepService::persistToDatabase(
-    std::tuple<common::crypto::Hash, std::string> bundle,
-    const std::vector<db::TransferInput>& deposits,
-    const std::vector<db::TransferInput>& hubInputs,
-    const std::vector<db::TransferOutput>& withdrawals,
-    const db::TransferOutput& hubOutput) {
-  auto& dbConnection = db::DBManager::get().connection();
-
-  // 6.1. Insert sweep.
-  auto sweepId = dbConnection.createSweep(std::get<0>(bundle),
-                                          std::get<1>(bundle), hubOutput.id);
-
-  // 6.2. Change Hub address balances
-
-  dbConnection.createHubAddressBalanceEntry(
-      hubOutput.id, hubOutput.amount, db::HubAddressBalanceReason::INBOUND,
-      sweepId);
-  for (const auto& input : hubInputs) {
-    dbConnection.createHubAddressBalanceEntry(
-        input.addressId, -input.amount, db::HubAddressBalanceReason::OUTBOUND,
-        sweepId);
-  }
-
-  // 6.3. Update withdrawal sweep id
-  for (const auto& withdrawal : withdrawals) {
-    dbConnection.setWithdrawalSweep(withdrawal.id, sweepId);
-  }
-
-  // 6.4. Change User address balances
-  for (const auto& input : deposits) {
-    dbConnection.createUserAddressBalanceEntry(
-        input.addressId, -input.amount, nonstd::nullopt,
-        db::UserAddressBalanceReason::SWEEP, {}, sweepId);
-
-    dbConnection.createUserAccountBalanceEntry(
-        input.userId, input.amount, db::UserAccountBalanceReason::SWEEP,
-        sweepId);
-  }
-}
 
 bool SweepService::doTick() {
   LOG(INFO) << "Starting sweep.";
@@ -301,12 +132,13 @@ bool SweepService::doTick() {
 
     // 4. Determine Hub output address
     auto remainder = (hubInputTotal + depositsTotal) - requiredOutput;
-    auto hubOutput = getHubOutput(remainder);
+    auto hubOutput = hub::bundle_utils::getHubOutput(remainder);
 
     LOG(INFO) << "Will move " << remainder
               << " into new Hub address: " << hubOutput.payoutAddress.str();
-    // 5. Generate bundle
-    auto bundle = createBundle(deposits, hubInputs, withdrawals, hubOutput);
+    // 5. Generate bundle_utils
+    auto bundle =
+        bundle_utils::createBundle(deposits, hubInputs, withdrawals, hubOutput);
 
     // 6. Commit to DB
     persistToDatabase(bundle, deposits, hubInputs, withdrawals, hubOutput);
@@ -327,5 +159,46 @@ bool SweepService::doTick() {
 
   return true;
 }
+
+void SweepService::persistToDatabase(
+    std::tuple<common::crypto::Hash, std::string> bundle,
+    const std::vector<db::TransferInput>& deposits,
+    const std::vector<db::TransferInput>& hubInputs,
+    const std::vector<db::TransferOutput>& withdrawals,
+    const db::TransferOutput& hubOutput) {
+  auto& dbConnection = db::DBManager::get().connection();
+
+  // 6.1. Insert sweep.
+  auto sweepId = dbConnection.createSweep(std::get<0>(bundle),
+                                          std::get<1>(bundle), hubOutput.id);
+
+  // 6.2. Change Hub address balances
+
+  dbConnection.createHubAddressBalanceEntry(
+      hubOutput.id, hubOutput.amount, db::HubAddressBalanceReason::INBOUND,
+      sweepId);
+  for (const auto& input : hubInputs) {
+    dbConnection.createHubAddressBalanceEntry(
+        input.addressId, -input.amount, db::HubAddressBalanceReason::OUTBOUND,
+        sweepId);
+  }
+
+  // 6.3. Update withdrawal sweep id
+  for (const auto& withdrawal : withdrawals) {
+    dbConnection.setWithdrawalSweep(withdrawal.id, sweepId);
+  }
+
+  // 6.4. Change User address balances
+  for (const auto& input : deposits) {
+    dbConnection.createUserAddressBalanceEntry(
+        input.addressId, -input.amount, nonstd::nullopt,
+        db::UserAddressBalanceReason::SWEEP, {}, sweepId);
+
+    dbConnection.createUserAccountBalanceEntry(
+        input.userId, input.amount, db::UserAccountBalanceReason::SWEEP,
+        sweepId);
+  }
+}
+
 }  // namespace service
 }  // namespace hub

--- a/hub/service/sweep_service.h
+++ b/hub/service/sweep_service.h
@@ -41,20 +41,19 @@ class SweepService : public ScheduledService {
   /// @return string - the descriptive name of the service
   const std::string name() const override { return "SweepService"; }
 
-
-    /// Persist the bundle data to database
-    /// identified during the sweep.
-    /// @param[in] bundle - the bundle hash and its serialized value
-    /// @param[in] deposits - a list of deposit transactions
-    /// @param[in] hubInputs - a list of internal transfers
-    /// @param[in] withdrawals - a list of withdrawal transactions
-    /// @param[in] hubOutput - the hub address into which the remainder is
-    /// deposited
-    void persistToDatabase(std::tuple<common::crypto::Hash, std::string> bundle,
-                           const std::vector<db::TransferInput>& deposits,
-                           const std::vector<db::TransferInput>& hubInputs,
-                           const std::vector<db::TransferOutput>& withdrawals,
-                           const db::TransferOutput& hubOutput);
+  /// Persist the bundle data to database
+  /// identified during the sweep.
+  /// @param[in] bundle - the bundle hash and its serialized value
+  /// @param[in] deposits - a list of deposit transactions
+  /// @param[in] hubInputs - a list of internal transfers
+  /// @param[in] withdrawals - a list of withdrawal transactions
+  /// @param[in] hubOutput - the hub address into which the remainder is
+  /// deposited
+  void persistToDatabase(std::tuple<common::crypto::Hash, std::string> bundle,
+                         const std::vector<db::TransferInput>& deposits,
+                         const std::vector<db::TransferInput>& hubInputs,
+                         const std::vector<db::TransferOutput>& withdrawals,
+                         const db::TransferOutput& hubOutput);
 
  protected:
   /// Called by tick() by default. Override in subclasses

--- a/hub/service/sweep_service.h
+++ b/hub/service/sweep_service.h
@@ -41,49 +41,25 @@ class SweepService : public ScheduledService {
   /// @return string - the descriptive name of the service
   const std::string name() const override { return "SweepService"; }
 
+
+    /// Persist the bundle data to database
+    /// identified during the sweep.
+    /// @param[in] bundle - the bundle hash and its serialized value
+    /// @param[in] deposits - a list of deposit transactions
+    /// @param[in] hubInputs - a list of internal transfers
+    /// @param[in] withdrawals - a list of withdrawal transactions
+    /// @param[in] hubOutput - the hub address into which the remainder is
+    /// deposited
+    void persistToDatabase(std::tuple<common::crypto::Hash, std::string> bundle,
+                           const std::vector<db::TransferInput>& deposits,
+                           const std::vector<db::TransferInput>& hubInputs,
+                           const std::vector<db::TransferOutput>& withdrawals,
+                           const db::TransferOutput& hubOutput);
+
  protected:
   /// Called by tick() by default. Override in subclasses
   /// @return false if it wants to stop.
   bool doTick() override;
-
-  /// Creates a new hub address to which funds that remain after a transfer
-  /// can be moved.
-  /// @param[in] remainder
-  /// @return a db::TransferOutput structure containing
-  /// - the new hub address
-  /// - the id of the new hub address
-  /// - the remainder
-  db::TransferOutput getHubOutput(uint64_t remainder);
-
-  /// Compute and serialize a bundle made up of all the deposits and withdrawals
-  /// identified during the sweep.
-  /// @param[in] deposits - a list of deposit transactions
-  /// @param[in] hubInputs - a list of internal transfers
-  /// @param[in] withdrawals - a list of withdrawal transactions
-  /// @param[in] hubOutput - a list of db::TransferOutput structures
-  /// @return a std::tuple containing
-  /// - the bundle hash
-  /// - the serialized bundle
-  std::tuple<common::crypto::Hash, std::string> createBundle(
-      const std::vector<db::TransferInput>& deposits,
-      const std::vector<db::TransferInput>& hubInputs,
-      const std::vector<db::TransferOutput>& withdrawals,
-      const db::TransferOutput& hubOutput);
-
-  /// Persist the bundle data to database
-  /// identified during the sweep.
-  /// @param[in] bundle - the bundle hash and its serialized value
-  /// @param[in] deposits - a list of deposit transactions
-  /// @param[in] hubInputs - a list of internal transfers
-  /// @param[in] withdrawals - a list of withdrawal transactions
-  /// @param[in] hubOutput - the hub address into which the remainder is
-  /// deposited
-  void persistToDatabase(std::tuple<common::crypto::Hash, std::string> bundle,
-                         const std::vector<db::TransferInput>& deposits,
-                         const std::vector<db::TransferInput>& hubInputs,
-                         const std::vector<db::TransferOutput>& withdrawals,
-                         const db::TransferOutput& hubOutput);
-
   /// an cppclient::IotaAPI compliant API provider
   const std::shared_ptr<cppclient::IotaAPI> _api;
 };

--- a/hub/service/sweep_service.h
+++ b/hub/service/sweep_service.h
@@ -55,6 +55,15 @@ class SweepService : public ScheduledService {
                          const std::vector<db::TransferOutput>& withdrawals,
                          const db::TransferOutput& hubOutput);
 
+  /// Creates a new hub address to which funds that remain after a transfer
+  /// can be moved.
+  /// @param[in] remainder
+  /// @return a db::TransferOutput structure containing
+  /// - the new hub address
+  /// - the id of the new hub address
+  /// - the remainder
+  db::TransferOutput getHubOutput(uint64_t remainder);
+
  protected:
   /// Called by tick() by default. Override in subclasses
   /// @return false if it wants to stop.

--- a/proto/hub.proto
+++ b/proto/hub.proto
@@ -40,5 +40,11 @@ service Hub {
   rpc WasWithdrawalCancelled (WasWithdrawalCancelledRequest) returns (WasWithdrawalCancelledReply);
   // Returns whether an address was spent from
   rpc WasAddressSpentFrom (WasAddressSpentFromRequest) returns (WasAddressSpentFromReply);
+  // Recover funds from an already spent address
+  //This API call is an alternative for "SignBundle" which requires the caller
+  //to first create the bundle with the address and the amount he/she is interested in
+  //instead, the "RecoverFunds" creates a bundle that spend the entire balance that
+  //is found on the given address
+  rpc RecoverFunds (RecoverFundsRequest) returns (RecoverFundsReply);
 }
 

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -48,6 +48,10 @@ enum ErrorCode {
   ADDRESS_WAS_ALREADY_SPENT = 16;
   //Provided uuid is invalid
   INVALID_UUID = 17;
+  //Provided address is not user's
+  WRONG_USER_ADDRESS = 18;
+  //Address's balance is zero
+  ADDRESS_BALANCE_ZERO = 19;
 }
 
 /*
@@ -342,4 +346,16 @@ message WasAddressSpentFromReply{
     //True if the address was spent from
     bool wasAddressSpentFrom = 1;
 }
+
+message RecoverFundsRequest {
+  string userId = 1;
+  // The Hub-owned IOTA address that should be signed. (without checksum)
+  string address = 2;
+  // should command validate address
+  bool validateChecksum = 3;
+  // Address the user requests payout to. Should be without checksum.
+  string payoutAddress = 4;
+}
+
+message RecoverFundsReply {}
 


### PR DESCRIPTION

This PR introduces a new API call which enables users to easily recover funds without from address that has been provided by GetDepositAddress endpoint and has been re-funded after a sweep has already occured, it is answering the same need as `SignBundle`, but whereas the `SignBundle` command lets the user create his/her own bundle and just provides the signature, this command detects the current balance in the "locked" address and creates a bundle that spends all of it to provided `payoutAddress`, the bundle is used to create a sweep and then used by the `reattachment_service`


## Type of change
- Enhancement (a non-breaking change which adds functionality)


# Checklist:

_Please delete items that are not relevant._

- [ ] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes

