### PR TITLE
reduce max_promotion_age

### DIFF
--- a/hub/service/attachment_service.cc
+++ b/hub/service/attachment_service.cc
@@ -25,7 +25,7 @@
 
 namespace {
 DEFINE_uint32(
-    max_promotion_age, 30,
+    max_promotion_age, 3,
     "Maximum age [minutes] for a sweep's tail which allows promotion, (i.e - a "
     "tail that's older than that will not be promoted, rather sweep "
     "will be reattached)");


### PR DESCRIPTION
# Description

Change max_promotion_age from 30 to 3 minutes because transactions below 15 milestones can't get confirmed and need to be reattached

## Type of change

- Enhancement (a non-breaking change which adds functionality)
